### PR TITLE
Patch to solve load problem

### DIFF
--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -3,13 +3,12 @@ require 'rake'
 
 # Load the test files from the command line.
 
-ARGV.each do |f| 
+ARGV.each do |f|
   next if f =~ /^-/
 
   if f =~ /\*/
-    FileList[f].to_a.each { |fn| load fn }
+    FileList[f].to_a.each { |fn| require File.expand_path(fn) }
   else
-    load f
+    require File.expand_path(f)
   end
 end
-


### PR DESCRIPTION
I had a problem with rails test in Ruby 1.9.3.
rake_test_loader used 'load' and test/unit used 'require', breaking tests that expected symbols not to be already defined.

The patch fixes the problem by replacing load with require, which prevents same files from later being loaded twice.

I didn't think a test was worth writing, since it would be testing Ruby load/require functionality.

Since this is related to unit tests, it shouldn't really break anything critical, even stuff that heavily relies on differences between load/require and/or load paths. Correct me if I am wrong.

And thanks for Rake! :)
