### PR TITLE
Avoid Ruby 1.9.3 warnings

### DIFF
--- a/lib/rake/alt_system.rb
+++ b/lib/rake/alt_system.rb
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2008 James M. Lawrence
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
 # (the "Software"), to deal in the Software without restriction,
@@ -8,10 +8,10 @@
 # publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so,
 # subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -27,9 +27,10 @@ require 'rbconfig'
 #
 # Alternate implementations of system() and backticks `` on Windows
 # for ruby-1.8 and earlier.
-# 
+#
 module Rake::AltSystem
-  WINDOWS = Config::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!
+  config = Kernel.const_defined?(:RbConfig) ? RbConfig : Config
+  WINDOWS = config::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw)!
 
   class << self
     def define_module_function(name, &block)
@@ -37,7 +38,7 @@ module Rake::AltSystem
       module_function(name)
     end
   end
-    
+
   if WINDOWS and RUBY_VERSION < "1.9.0"
     RUNNABLE_EXTS = %w[com exe bat cmd]
     RUNNABLE_PATTERN = %r!\.(#{RUNNABLE_EXTS.join('|')})\Z!i

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -5,7 +5,7 @@ require 'rake/task_manager'
 require 'rake/win32'
 
 module Rake
-  
+
   ######################################################################
   # Rake main application object.  When invoking +rake+ from the
   # command line, a Rake::Application object is created and run.
@@ -232,7 +232,7 @@ module Rake
       80
     end
 
-    # Calculate the dynamic width of the 
+    # Calculate the dynamic width of the
     def dynamic_width
       @dynamic_width ||= (dynamic_width_stty.nonzero? || dynamic_width_tput)
     end
@@ -246,9 +246,10 @@ module Rake
     end
 
     def unix?
-      Config::CONFIG['host_os'] =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
+      config = Kernel.const_defined?(:RbConfig) ? RbConfig : Config
+      config::CONFIG['host_os'] =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
     end
-    
+
     def windows?
       Win32.windows?
     end
@@ -308,7 +309,7 @@ module Rake
         ],
         ['--execute-continue',  '-E CODE',
           "Execute some Ruby code, then continue with normal task processing.",
-          lambda { |value| eval(value) }            
+          lambda { |value| eval(value) }
         ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
@@ -320,9 +321,9 @@ module Rake
           lambda { |value| Rake.verbose(false) }
         ],
         ['--rakefile', '-f [FILE]', "Use FILE as the rakefile.",
-          lambda { |value| 
+          lambda { |value|
             value ||= ''
-            @rakefiles.clear 
+            @rakefiles.clear
             @rakefiles << value
           }
         ],
@@ -337,7 +338,7 @@ module Rake
             rescue LoadError => ex
               begin
                 rake_require value
-              rescue LoadError => ex2
+              rescue LoadError
                 raise ex
               end
             end
@@ -509,7 +510,7 @@ module Rake
           end
         end
     end
-    
+
     # The standard directory containing system wide rake files.
     if Win32.windows?
       def standard_system_dir #:nodoc:

--- a/lib/rake/contrib/ftptools.rb
+++ b/lib/rake/contrib/ftptools.rb
@@ -25,7 +25,7 @@ module Rake # :nodoc:
 
     def initialize(path, entry)
       @path = path
-      @mode, line, @owner, @group, size, d1, d2, d3, @name = entry.split(' ')
+      @mode, _, @owner, @group, size, d1, d2, d3, @name = entry.split(' ') # _ = line
       @size = size.to_i
       @time = determine_time(d1, d2, d3)
     end
@@ -59,7 +59,7 @@ module Rake # :nodoc:
     def determine_time(d1, d2, d3)
       now = self.class.time.now
       if /:/ =~ d3
-        h, m = d3.split(':')
+        #h, m = d3.split(':')
         result = Time.parse("#{d1} #{d2} #{now.year} #{d3}")
         if result > now
           result = Time.parse("#{d1} #{d2} #{now.year-1} #{d3}")
@@ -134,7 +134,7 @@ module Rake # :nodoc:
         upload(fn)
       end
     end
-    
+
     # Close the uploader.
     def close
       @ftp.close

--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -7,9 +7,10 @@ require 'fileutils'
 #
 module FileUtils
   # Path to the currently running Ruby program
+  config = Kernel.const_defined?(:RbConfig) ? RbConfig : Config
   RUBY = File.join(
-    Config::CONFIG['bindir'],
-    Config::CONFIG['ruby_install_name'] + Config::CONFIG['EXEEXT']).
+    config::CONFIG['bindir'],
+    config::CONFIG['ruby_install_name'] + config::CONFIG['EXEEXT']).
     sub(/.*\s.*/m, '"\&"')
 
   OPT_TABLE['sh']  = %w(noop verbose)
@@ -49,7 +50,7 @@ module FileUtils
   def create_shell_runner(cmd)
     show_command = cmd.join(" ")
     show_command = show_command[0,42] + "..." unless $trace
-    block = lambda { |ok, status|
+    lambda { |ok, status|
       ok or fail "Command failed with status (#{status.exitstatus}): [#{show_command}]"
     }
   end
@@ -91,7 +92,7 @@ module FileUtils
     else
       begin
         ln(*args)
-      rescue StandardError, NotImplementedError => ex
+      rescue StandardError, NotImplementedError
         LN_SUPPORTED[0] = false
         cp(*args)
       end

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -15,7 +15,7 @@ module Rake
     end
 
     def create_rule(*args, &block)
-      pattern, arg_names, deps = resolve_args(args)
+      pattern, _, deps = resolve_args(args) # _ = arg_names
       pattern = Regexp.new(Regexp.quote(pattern) + '$') if String === pattern
       @rules << [pattern, deps, block]
     end
@@ -84,7 +84,7 @@ module Rake
       [task_name, arg_names, []]
     end
     private :resolve_args_without_dependencies
-    
+
     # Resolve task arguments for a task or rule when there are
     # dependencies declared.
     #
@@ -115,7 +115,7 @@ module Rake
       [task_name, arg_names, deps]
     end
     private :resolve_args_with_dependencies
-    
+
     # If a rule can be found that matches the task name, enhance the
     # task with the prerequisites and actions from the rule.  Set the
     # source attribute of the task appropriately for the rule.  Return
@@ -124,7 +124,7 @@ module Rake
       fail Rake::RuleRecursionOverflowError,
         "Rule Recursion Too Deep" if level >= 16
       @rules.each do |pattern, extensions, block|
-        if md = pattern.match(task_name)
+        if pattern.match(task_name)
           task = attempt_rule(task_name, extensions, block, level)
           return task if task
         end
@@ -207,14 +207,14 @@ module Rake
     end
 
     private
-    
+
     # Add a location to the locations field of the given task.
     def add_location(task)
       loc = find_location
       task.locations << loc if loc
       task
     end
-    
+
     # Find the location that called into the dsl layer.
     def find_location
       locations = caller
@@ -225,7 +225,7 @@ module Rake
       end
       nil
     end
-      
+
     # Generate an anonymous namespace name.
     def generate_name
       @seed ||= 0
@@ -284,8 +284,8 @@ module Rake
     end
 
 
-    private 
-    
+    private
+
     # Return the current description. If there isn't one, try to find it
     # by reading in the source file and looking for a comment immediately
     # prior to the task definition
@@ -294,14 +294,14 @@ module Rake
       @last_description = nil
       desc
     end
-    
+
     def find_preceding_comment_for_task(task)
       loc = task.locations.last
       file_name, line = parse_location(loc)
       return nil unless file_name
       comment_from_file(file_name, line)
     end
-    
+
     def parse_location(loc)
       if loc =~ /^(.*):(\d+)/
         [ $1, Integer($2) ]

--- a/test/lib/application_test.rb
+++ b/test/lib/application_test.rb
@@ -26,7 +26,7 @@ class TestApplication < Test::Unit::TestCase
     @app.options.rakelib = []
     Rake::TaskManager.record_task_metadata = true
   end
-  
+
   def teardown
     Rake::TaskManager.record_task_metadata = false
     super
@@ -67,7 +67,7 @@ class TestApplication < Test::Unit::TestCase
       @app.options.show_task_pattern = //
       description = "something short"
       task_name = "task name" * 80
-      @app.last_description = "something short"
+      @app.last_description = description
       @app.define_task(Rake::Task, task_name )
       out = capture_stdout do @app.instance_eval { display_tasks_and_comments } end
       # Ensure the entire task name is output and we end up showing no description
@@ -144,7 +144,7 @@ class TestApplication < Test::Unit::TestCase
 
   def test_load_rakefile
     in_environment("PWD" => "test/data/unittest") do
-      @app.instance_eval do 
+      @app.instance_eval do
         handle_options
         options.silent = true
         load_rakefile
@@ -172,8 +172,8 @@ class TestApplication < Test::Unit::TestCase
         handle_options
         options.silent = true
       end
-      ex = assert_exception(RuntimeError) do 
-        @app.instance_eval do raw_load_rakefile end 
+      ex = assert_exception(RuntimeError) do
+        @app.instance_eval do raw_load_rakefile end
       end
       assert_match(/no rakefile found/i, ex.message)
     end
@@ -306,7 +306,7 @@ class TestApplication < Test::Unit::TestCase
     ARGV.clear
     ARGV << '-f' << '-s' << '--xyzzy'
     assert_exception(SystemExit) {
-      err = capture_stderr { capture_stdout { @app.run } }
+      capture_stderr { capture_stdout { @app.run } }
     }
   ensure
     ARGV.clear
@@ -332,7 +332,7 @@ class TestApplicationOptions < Test::Unit::TestCase
     Rake::FileUtilsExt.verbose_flag = false
     Rake::FileUtilsExt.nowrite_flag = false
   end
-  
+
   def clear_argv
     while ! ARGV.empty?
       ARGV.pop
@@ -470,14 +470,14 @@ class TestApplicationOptions < Test::Unit::TestCase
       assert_equal 3, TESTING_REQUIRE.size
     end
   end
-  
+
   def test_missing_require
     in_environment do
       ex = assert_exception(LoadError) do
         flags(['--require', 'test/missing']) do |opts|
         end
       end
-      assert_match(/no such file/, ex.message)
+      assert_match(/(cannot load such file|no such file)/, ex.message)
       assert_match(/test\/missing/, ex.message)
     end
   end
@@ -581,7 +581,7 @@ class TestApplicationOptions < Test::Unit::TestCase
       end
     end
   end
-  
+
   def test_classic_namespace
     in_environment do
       flags(['--classic-namespace'], ['-C', '-T', '-P', '-n', '-s', '-t']) do |opts|
@@ -599,7 +599,7 @@ class TestApplicationOptions < Test::Unit::TestCase
     in_environment do
       error_output = capture_stderr do
         ex = assert_exception(OptionParser::InvalidOption) do
-          flags('--bad-option') 
+          flags('--bad-option')
         end
         if ex.message =~ /^While/ # Ruby 1.9 error message
           assert_match(/while parsing/i, ex.message)
@@ -616,12 +616,12 @@ class TestApplicationOptions < Test::Unit::TestCase
     command_line("a", "b")
     assert_equal ["a", "b"], @tasks.sort
   end
-  
+
   def test_default_task_collection
     command_line()
     assert_equal ["default"], @tasks
   end
-  
+
   def test_environment_definition
     ENV.delete('TESTKEY')
     command_line("a", "TESTKEY=12")
@@ -629,13 +629,13 @@ class TestApplicationOptions < Test::Unit::TestCase
     assert '12', ENV['TESTKEY']
   end
 
-  private 
+  private
 
   def flags(*sets)
     sets.each do |set|
       ARGV.clear
-      @out = capture_stdout { 
-        @exit = catch(:system_exit) { opts = command_line(*set) }
+      @out = capture_stdout {
+        @exit = catch(:system_exit) { command_line(*set) }
       }
       yield(@app.options) if block_given?
     end
@@ -660,31 +660,31 @@ class TestTaskArgumentParsing < Test::Unit::TestCase
   def setup
     @app = Rake::Application.new
   end
-  
+
   def test_name_only
     name, args = @app.parse_task_string("name")
     assert_equal "name", name
     assert_equal [], args
   end
-  
+
   def test_empty_args
     name, args = @app.parse_task_string("name[]")
     assert_equal "name", name
     assert_equal [], args
   end
-  
+
   def test_one_argument
     name, args = @app.parse_task_string("name[one]")
     assert_equal "name", name
     assert_equal ["one"], args
   end
-  
+
   def test_two_arguments
     name, args = @app.parse_task_string("name[one,two]")
     assert_equal "name", name
     assert_equal ["one", "two"], args
   end
-  
+
   def test_can_handle_spaces_between_args
     name, args = @app.parse_task_string("name[one, two,\tthree , \tfour]")
     assert_equal "name", name

--- a/test/lib/earlytime_test.rb
+++ b/test/lib/earlytime_test.rb
@@ -6,7 +6,6 @@ require 'rake'
 class TestEarlyTime < Test::Unit::TestCase
   def test_create
     early = Rake::EarlyTime.instance
-    time = Time.mktime(1970, 1, 1, 0, 0, 0)
     assert early <= Time.now
     assert early < Time.now
     assert early != Time.now
@@ -26,7 +25,7 @@ class TestEarlyTime < Test::Unit::TestCase
     assert t1 < t2
     assert t2 > t1
     assert t1 == t1
-    assert t2 == t2    
+    assert t2 == t2
   end
 
   def test_to_s

--- a/test/lib/filelist_test.rb
+++ b/test/lib/filelist_test.rb
@@ -87,7 +87,7 @@ class TestFileList < Test::Unit::TestCase
     h = f.include("y")
     assert_equal f.object_id, h.object_id
   end
-  
+
   def test_match
     fl = FileList.new
     fl.include('test/lib/*_test.rb')
@@ -153,7 +153,7 @@ class TestFileList < Test::Unit::TestCase
     fl.exclude('testdata/existing')
     assert_equal [], fl
   end
-  
+
   def test_excluding_via_block
     fl = FileList['testdata/a.c', 'testdata/b.c', 'testdata/xyz.c']
     fl.exclude { |fn| fn.pathmap('%n') == 'xyz' }
@@ -233,24 +233,24 @@ class TestFileList < Test::Unit::TestCase
     assert_equal ["testdata/abc.o", "testdata/x.o", "testdata/xyz.o"].sort,
       f3.sort
   end
-  
+
   def test_claim_to_be_a_kind_of_array
     fl = FileList['testdata/*.c']
     assert fl.is_a?(Array)
     assert fl.kind_of?(Array)
   end
-  
+
   def test_claim_to_be_a_kind_of_filelist
     fl = FileList['testdata/*.c']
     assert fl.is_a?(FileList)
     assert fl.kind_of?(FileList)
   end
-  
+
   def test_claim_to_be_a_filelist_instance
     fl = FileList['testdata/*.c']
     assert fl.instance_of?(FileList)
   end
-  
+
   def test_dont_claim_to_be_an_array_instance
     fl = FileList['testdata/*.c']
     assert ! fl.instance_of?(Array)
@@ -325,7 +325,7 @@ class TestFileList < Test::Unit::TestCase
 
   def test_egrep_returns_0_if_no_matches
     files = FileList['test/lib/*_test.rb'].exclude("test/lib/filelist_test.rb")
-    the_line_number = __LINE__ + 1
+    #the_line_number = __LINE__ + 1
     assert_equal 0, files.egrep(/XYZZY/) { }
   end
 
@@ -593,12 +593,12 @@ class TestFileList < Test::Unit::TestCase
     assert_equal ['b', 'd'], r
     assert_equal FileList, r.class
   end
-  
+
   def test_file_utils_can_use_filelists
     cfiles = FileList['testdata/*.c']
-    
+
     cp cfiles, @cdir, :verbose => false
-    
+
     assert File.exist?(File.join(@cdir, 'abc.c'))
     assert File.exist?(File.join(@cdir, 'xyz.c'))
     assert File.exist?(File.join(@cdir, 'x.c'))
@@ -606,7 +606,7 @@ class TestFileList < Test::Unit::TestCase
 
   def create_test_data
     verbose(false) do
-      
+
       mkdir "testdata" unless File.exist? "testdata"
       mkdir "testdata/CVS" rescue nil
       mkdir "testdata/.svn" rescue nil
@@ -624,5 +624,5 @@ class TestFileList < Test::Unit::TestCase
       touch "testdata/existing"
     end
   end
-  
+
 end

--- a/test/lib/package_task_test.rb
+++ b/test/lib/package_task_test.rb
@@ -43,7 +43,7 @@ class TestPackageTask < Test::Unit::TestCase
 
   def test_missing_version
     assert_exception(RuntimeError) {
-      pkg = Rake::PackageTask.new("pkgr") { |p| }
+      Rake::PackageTask.new("pkgr") { |p| }
     }
   end
 

--- a/test/lib/pathmap_test.rb
+++ b/test/lib/pathmap_test.rb
@@ -27,7 +27,7 @@ class TestPathMap < Test::Unit::TestCase
 
   def test_n_returns_basename_without_extension
     assert_equal "abc", "abc.rb".pathmap("%n")
-    assert_equal "abc", "abc".pathmap("%n") 
+    assert_equal "abc", "abc".pathmap("%n")
     assert_equal "abc", "this/is/a/dir/abc.rb".pathmap("%n")
     assert_equal "abc", "/this/is/a/dir/abc.rb".pathmap("%n")
     assert_equal "abc", "/this/is/a/dir/abc".pathmap("%n")
@@ -88,7 +88,7 @@ class TestPathMap < Test::Unit::TestCase
   end
 
   def test_undefined_percent_causes_error
-    ex = assert_exception(ArgumentError) {
+    assert_exception(ArgumentError) {
       "dir/abc.rb".pathmap("%z")
     }
   end

--- a/test/lib/rdoc_task_test.rb
+++ b/test/lib/rdoc_task_test.rb
@@ -7,18 +7,18 @@ require 'test/rake_test_setup'
 class TestRDocTask < Test::Unit::TestCase
   include Rake
   include TestMethods
-  
+
   def setup
     Task.clear
   end
-  
+
   def test_tasks_creation
     Rake::RDocTask.new
     assert Task[:rdoc]
     assert Task[:clobber_rdoc]
     assert Task[:rerdoc]
   end
-  
+
   def test_tasks_creation_with_custom_name_symbol
     rd = Rake::RDocTask.new(:rdoc_dev)
     assert Task[:rdoc_dev]
@@ -26,7 +26,7 @@ class TestRDocTask < Test::Unit::TestCase
     assert Task[:rerdoc_dev]
     assert_equal :rdoc_dev, rd.name
   end
-  
+
   def test_tasks_creation_with_custom_name_string
     rd = Rake::RDocTask.new("rdoc_dev")
     assert Task[:rdoc_dev]
@@ -34,7 +34,7 @@ class TestRDocTask < Test::Unit::TestCase
     assert Task[:rerdoc_dev]
     assert_equal "rdoc_dev", rd.name
   end
-  
+
   def test_tasks_creation_with_custom_name_hash
     options = { :rdoc => "rdoc", :clobber_rdoc => "rdoc:clean", :rerdoc => "rdoc:force" }
     rd = Rake::RDocTask.new(options)
@@ -44,42 +44,42 @@ class TestRDocTask < Test::Unit::TestCase
     assert_raises(RuntimeError) { Task[:clobber_rdoc] }
     assert_equal options, rd.name
   end
-  
+
   def test_tasks_creation_with_custom_name_hash_will_use_default_if_an_option_isnt_given
-    rd = Rake::RDocTask.new(:clobber_rdoc => "rdoc:clean")
+    Rake::RDocTask.new(:clobber_rdoc => "rdoc:clean")
     assert Task[:rdoc]
     assert Task[:"rdoc:clean"]
     assert Task[:rerdoc]
   end
-  
+
   def test_tasks_creation_with_custom_name_hash_raises_exception_if_invalid_option_given
     assert_raises(ArgumentError) do
       Rake::RDocTask.new(:foo => "bar")
     end
-    
+
     begin
       Rake::RDocTask.new(:foo => "bar")
     rescue ArgumentError => e
       assert_match(/foo/, e.message)
     end
   end
-  
+
   def test_inline_source_is_enabled_by_default
     rd = Rake::RDocTask.new
     assert rd.option_list.include?('--inline-source')
   end
-  
+
   def test_inline_source_option_is_only_appended_if_option_not_already_given
     rd = Rake::RDocTask.new
     rd.options << '--inline-source'
     assert_equal 1, rd.option_list.grep('--inline-source').size
-    
+
     rd = Rake::RDocTask.new
     rd.options << '-S'
     assert_equal 1, rd.option_list.grep('-S').size
     assert_equal 0, rd.option_list.grep('--inline-source').size
   end
-  
+
   def test_inline_source_option_can_be_disabled
     rd = Rake::RDocTask.new
     rd.inline_source = false

--- a/test/lib/rules_test.rb
+++ b/test/lib/rules_test.rb
@@ -278,7 +278,6 @@ class TestRules < Test::Unit::TestCase
   end
 
   def test_rule_with_proc_dependent_will_trigger
-    ran = false
     mkdir_p("testdata/src/jw")
     create_file("testdata/src/jw/X.java")
     rule %r(classes/.*\.class) => [

--- a/test/lib/task_manager_test.rb
+++ b/test/lib/task_manager_test.rb
@@ -72,7 +72,7 @@ class TestTaskManager < Test::Unit::TestCase
 
   def test_name_lookup_with_nonexistent_task
     assert_exception(RuntimeError) {
-      t = @tm["DOES NOT EXIST"]
+      @tm["DOES NOT EXIST"]
     }
   end
 
@@ -129,7 +129,7 @@ class TestTaskManager < Test::Unit::TestCase
       end
     end
     assert_equal t1, @tm[:t, []]
-    assert_equal t2, @tm[:t, ["a"]]    
+    assert_equal t2, @tm[:t, ["a"]]
     assert_equal t3, @tm[:t, ["a", "b"]]
     assert_equal s,  @tm[:s, ["a", "b"]]
     assert_equal s,  @tm[:s, ["a"]]
@@ -147,7 +147,7 @@ class TestTaskManager < Test::Unit::TestCase
     @tm["a:x"].invoke
     assert_equal ["next z"], values
   end
-  
+
 end
 
 class TestTaskManagerArgumentResolution < Test::Unit::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 begin
   require 'rubygems'
-rescue LoadError => ex
+rescue LoadError
   # No rubygems available
 end
 require 'test/unit'


### PR DESCRIPTION
Removed some of the warnings present on 1.9.3.

I have both git and vim set to make trailing spaces a non-issue for me, but I keep forgetting that github makes this painfully visible to others. Sorry about that. 

Normally, I would go back and separate commits, but since these are really cosmetic changes for warnings, I just gave up.
