### PR TITLE
Fix misfind bugs in rakefile_location

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -569,11 +569,9 @@ module Rake
     end
 
     def rakefile_location
-      begin
-        fail
-      rescue RuntimeError => ex
-        ex.backtrace.find {|str| str =~ /#{@rakefile}/ } || ""
-      end
+      bt = caller
+      bt.map { |t| t[/([^:]+):/,1] }
+      bt.find {|str| str =~ /^#{@rakefile}$/ } || ""
     end
   end
 end


### PR DESCRIPTION
If @rakefile is nil, or if the caller contains rakefile (which includes rakefile_location!!) then directory discovery comes back incorrect.

This was affecting bundler on win32.
