### PR TITLE
Allow non-rails apps to load all the gem tasks defined in the gems they're using

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -503,13 +503,15 @@ module Rake
       # load gem rake files if Bundler is defined
       if defined?(Bundler)
         Bundler.load.specs.each do |spec|
-          #look for tasks in the gem's load paths, most will be lib/GEM_DIR/tasks
+          #look for tasks in the gem's load paths
           spec.load_paths.each do  |load_path|
-            Dir.foreach(load_path) do |path|
-              gem_tasks_dir = File.join(load_path, path, 'tasks')
-              if File.directory?(gem_tasks_dir)
-                glob("#{gem_tasks_dir}/*.rake") do |name|
-                  add_import name
+            if File.directory?(load_path)
+              Dir.foreach(load_path) do |path|
+                check_dir = File.join(load_path, path)
+                if File.directory?(check_dir)
+                  glob("#{check_dir}/**/*.rake") do |name|
+                    add_import name
+                  end
                 end
               end
             end

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -499,6 +499,24 @@ module Rake
           end
         end
       end
+      
+      # load gem rake files if Bundler is defined
+      if defined?(Bundler)
+        Bundler.load.specs.each do |spec|
+          #look for tasks in the gem's load paths, most will be lib/GEM_DIR/tasks
+          spec.load_paths.each do  |load_path|
+            Dir.foreach(load_path) do |path|
+              gem_tasks_dir = File.join(load_path, path, 'tasks')
+              if File.directory?(gem_tasks_dir)
+                glob("#{gem_tasks_dir}/*.rake") do |name|
+                  add_import name
+                end
+              end
+            end
+          end
+        end
+      end
+      
       load_imports
     end
 


### PR DESCRIPTION
If Bundler is defined, Rake::Application.raw_load_rakefile will now look for rake tasks in the load paths associated with all the gems used and load all of the rake tasks.

Ex: orientdb gem has loadpath [systempath]/orientdb/lib/orientdb
 => rake would find tasks located in [systempath]/orientdb/lib/orientdb/tasks/database,rake (and if it existed: [systempath]/orientdb/lib/orientdb/hi.rake)

Background:
I made this patch so that people would not need to manually require the rake tasks they want from their gems and instead, could have it all automated by rake.  There would then be no reason for railties having to declare their rake tasks.  If somebody wanted to ensure that a specific task was used and not overwritten, then they could require the file that loads that task in their Rakefile.

When referencing the orientdb gem, I'm referencing the current build I'm working on, not the master.  My build is at - https://github.com/ricaurte/orientdb-jruby/
