### PR TITLE
Gem::Specification#default_executable= is deprecated

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -234,7 +234,6 @@ else
 
     s.bindir = "bin"                               # Use these for applications.
     s.executables = ["rake"]
-    s.default_executable = "rake"
 
     #### Documentation and testing.
 


### PR DESCRIPTION
removed `s.default_executable = "rake"` from Rakefile's gem specification.

new rubygems warns deprecation of this option, and says after 2011/10/01 it will be removed.
