### PR TITLE
require 'rake/dsl' should extend the toplevel object

### DIFF
--- a/lib/rake/dsl.rb
+++ b/lib/rake/dsl.rb
@@ -1,2 +1,2 @@
 require 'rake'
-include Rake::DSL
+extend Rake::DSL


### PR DESCRIPTION
The old 'include' line is there, a remnant of the time when Rake's toplevel wasn't toplevel.

This is somewhat urgent because people think rake/dsl is intended to revert to the old behavior of Rake::DSL infecting all objects. Someone using "require 'rake/dsl'" to obtain the old behavior will have introduced an incompatible change.
