### PR TITLE
Deprecate the Top Level DSL rather than removing it

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -430,6 +430,8 @@ module Rake
         opts.environment('RAKEOPT')
       end.parse!
 
+      Object.send(:include, Rake::DSL::DeprecatedVersion)
+
       # If class namespaces are requested, set the global options
       # according to the values in the options structure.
       if options.classic_namespace

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -135,6 +135,30 @@ module Rake
         Rake.application.add_import(fn)
       end
     end
+
+    module DeprecatedVersion
+      def self.append_features(base)
+        base.send(:include, Rake::DSL)
+        super
+      end
+
+      def _warn_once(method_name)
+        @toplevel_method_warning ||= false
+        if !@toplevel_method_warning
+          $stderr.write "Rake::DSL is no longer included in Object.  Be sure you require 'rake/dsl' or include Rake::DSL before trying to use #{method_name.inspect} as this functionality will be removed in rake 1.0.\n"
+          @toplevel_method_warning = true
+        end
+      end
+
+      [:task, :desc, :import, :rule, :namespace, :multitask, :directory, :file, :file_create].each do |deprecated_method|
+        class_eval <<-EOT
+        def #{deprecated_method}(*args)
+          _warn_once("#{deprecated_method}")
+          super
+        end
+        EOT
+      end
+    end
   end
 
   extend FileUtilsExt

--- a/test/data/access/Rakefile
+++ b/test/data/access/Rakefile
@@ -16,10 +16,13 @@ end
 
 task :obj do
   begin
-    Object.new.instance_eval { task :xyzzy }
-    puts "BAD:D  Rake DSL are polluting objects"
-  rescue StandardError => ex
+    _, stderr = capture_io do
+      Object.new.instance_eval { task :xyzzy }
+    end
+  if stderr[/deprecated/]
     puts "GOOD:D Rake DSL are not polluting objects"
+  else
+    puts "BAD:D  Rake DSL are polluting objects"
   end
 end
 

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -28,9 +28,15 @@ class TestRakeDsl < Rake::TestCase
     refute_nil Rake::Task["bob:t"]
   end
 
-  def test_dsl_not_toplevel_by_default
-    actual = TOPLEVEL_BINDING.instance_eval { defined?(task) }
-    assert_nil actual
+  def test_toplevel_dsl_deprecated
+    _, stderr = capture_io do
+      TOPLEVEL_BINDING.instance_eval do
+        task :something do
+        end
+      end
+    end
+
+    assert_match /Rake::DSL/, stderr, "Top Level DSL should be deprecated"
   end
 
   def test_dsl_toplevel_when_require_rake_dsl


### PR DESCRIPTION
The removal of Rake::DSL from object is understandable but has introduced a lot of breakage, rather than removing the functionality wholesale, I'd like to propose a period of time where rake prints warnings.  Ideally this will give people time to update their code before rake 1.0 ships when it can be removed completely.
