### PR TITLE
bin/rake should activate gem if available

### DIFF
--- a/bin/rake
+++ b/bin/rake
@@ -24,6 +24,7 @@
 
 begin
   require 'rubygems'
+  gem 'rake'
 rescue LoadError
 end
 


### PR DESCRIPTION
With latest ([1a6a4ca](https://github.com/jimweirich/rake/commit/1a6a4ca)), the rake gem is still picking up the built-in rake. For example

```
% gem install boc
```

fails with

```
rake aborted!
uninitialized constant Rake::DSL
[...]
/install/path/lib/ruby/1.9.1/rake.rb:2006:in `load_rakefile'
/install/path/lib/ruby/1.9.1/rake.rb:1991:in `run'
/install/path/lib/ruby/gems/1.9.1/gems/rake-0.9.0/bin/rake:32:in `<main>'
```
