### PR TITLE
DSL changes

### DIFF
--- a/lib/rake/dsl.rb
+++ b/lib/rake/dsl.rb
@@ -1,2 +1,0 @@
-require 'rake'
-include Rake::DSL

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -12,6 +12,8 @@ module Rake
     private(*FileUtils.instance_methods(false))
     private(*FileUtilsExt.instance_methods(false))
 
+    private
+
     # Declare a basic task.
     #
     # Example:

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -139,7 +139,21 @@ module Rake
     end
   end
 
+  module DeprecatedObjectDSL
+    dsl = Object.new.extend DSL
+    DSL.private_instance_methods(false).each do |name|
+      define_method name do |*args, &block|
+        $stderr.puts "WARNING: Relying upon the Rake DSL being accessible " <<
+          "everywhere is deprecated.  Include Rake::DSL into classes which " <<
+          "use the Rake DSL methods. (#{self.class}##{name} called.)"
+        dsl.send(name, *args, &block)
+      end
+      private name
+    end
+  end
+
   extend FileUtilsExt
 end
 
 self.extend Rake::DSL
+include Rake::DeprecatedObjectDSL

--- a/test/data/access/Rakefile
+++ b/test/data/access/Rakefile
@@ -14,7 +14,9 @@ task :work do
   end
 end
 
-task :obj do
+# TODO: remove `disabled_' when DeprecatedObjectDSL removed
+task :obj
+task :disabled_obj do
   begin
     Object.new.instance_eval { task :xyzzy }
     puts "BAD:D  Rake DSL are polluting objects"

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -27,4 +27,25 @@ class TestRakeDsl < Rake::TestCase
     end
     refute_nil Rake::Task["bob:t"]
   end
+
+  class Foo
+    def initialize
+      task :foo_deprecated_a => :foo_deprecated_b do
+        print "a"
+      end
+      task :foo_deprecated_b do
+        print "b"
+      end
+    end
+  end
+
+  def test_deprecated_object_dsl
+    out, err = capture_io do
+      Foo.new
+      Rake.application.invoke_task :foo_deprecated_a
+    end
+    assert_equal("ba", out)
+    assert_match(/deprecated/, err)
+    assert_match(/Foo\#task/, err)
+  end
 end

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -27,15 +27,4 @@ class TestRakeDsl < Rake::TestCase
     end
     refute_nil Rake::Task["bob:t"]
   end
-
-  def test_dsl_not_toplevel_by_default
-    actual = TOPLEVEL_BINDING.instance_eval { defined?(task) }
-    assert_nil actual
-  end
-
-  def test_dsl_toplevel_when_require_rake_dsl
-    ruby '-I./lib', '-rrake/dsl', '-e', 'task(:x) { }', :verbose => false
-
-    assert $?.exitstatus
-  end
 end


### PR DESCRIPTION
I've lumped these together since they are sequentially dependent.
- Rake DSL methods should be private.
- The original purpose of <code>require 'rake/dsl'</code> was to provide a non-Rake application with the top level DSL. However the top level DSL is now permanent (<code>extend Rake::DSL</code> appears at the end of dsl_definition.rb), and apart from very contrived solutions (such as temporarily adding it during loading with a recursion counter), I don't see a decent way to make the top level DSL optional again.
- Make the DSL globally accessible through Object again; emit deprecation warnings when such use occurs. I looked at NZKoz's pull request (#37) but there were too many problems with it (sorry).
