### PR TITLE
Add --cron option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ r19.diff
 temp_*
 testdata
 x
+.redcar

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -144,13 +144,13 @@ module Rake
     def display_error_message(ex)
       $stderr.puts "#{name} aborted!"
       $stderr.puts ex.message
-      if options.trace
+      if options.trace or options.cron
         $stderr.puts ex.backtrace.join("\n")
       else
         $stderr.puts rakefile_location(ex.backtrace)
       end
       $stderr.puts "Tasks: #{ex.chain}" if has_chain?(ex)
-      $stderr.puts "(See full trace by running task with --trace)" unless options.trace
+      $stderr.puts "(See full trace by running task with --trace)" unless options.trace or options.cron
     end
 
     # Warn about deprecated usage.
@@ -386,6 +386,12 @@ module Rake
           lambda { |value|
             options.trace = true
             Rake.verbose(true)
+          }
+        ],
+        ['--cron', '-c', "Like --silent, but full backtraces are printed on errors (useful for cronjobs)",
+          lambda { |value|
+            options.cron   = true
+            options.silent = true
           }
         ],
         ['--verbose', '-v', "Log message to standard output.",

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -388,10 +388,11 @@ module Rake
             Rake.verbose(true)
           }
         ],
-        ['--cron', '-c', "Like --silent, but full backtraces are printed on errors (useful for cronjobs)",
+        ['--cron', '-c', "Like -s and -X, but full backtraces are printed on errors (useful for cronjobs)",
           lambda { |value|
             options.cron   = true
             options.silent = true
+            options.ignore_deprecate = true
           }
         ],
         ['--verbose', '-v', "Log message to standard output.",

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,6 +35,16 @@ class Rake::TestCase < MiniTest::Unit::TestCase
   ensure
     Rake.application.options.ignore_deprecate = false
   end
+  
+  def rake_capture_io(captured_stdout, captured_stderr)
+    orig_stdout, orig_stderr         = $stdout, $stderr
+    $stdout, $stderr                 = captured_stdout, captured_stderr
+  
+    yield
+  ensure
+    $stdout = orig_stdout
+    $stderr = orig_stderr
+  end
 
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,16 +36,6 @@ class Rake::TestCase < MiniTest::Unit::TestCase
     Rake.application.options.ignore_deprecate = false
   end
   
-  def rake_capture_io(captured_stdout, captured_stderr)
-    orig_stdout, orig_stderr         = $stdout, $stderr
-    $stdout, $stderr                 = captured_stdout, captured_stderr
-  
-    yield
-  ensure
-    $stdout = orig_stdout
-    $stderr = orig_stderr
-  end
-
 end
 
 # workarounds for 1.8

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -319,10 +319,12 @@ class TestRakeApplication < Rake::TestCase
     @app.intern(Rake::Task, "default").enhance { fail }
     ARGV.clear
     ARGV << '-f' << '-s' <<  '--rakelib=""'
+    out, err = StringIO.new, StringIO.new
     assert_raises(SystemExit) {
-      _, err = capture_io { @app.run }
-      assert_match(/see full trace/, err)
+      rake_capture_io(out, err) { @app.run }
     }
+    err.rewind
+    assert_match(/See full trace/, err.read)
   ensure
     ARGV.clear
   end
@@ -331,10 +333,12 @@ class TestRakeApplication < Rake::TestCase
     @app.intern(Rake::Task, "default").enhance { fail }
     ARGV.clear
     ARGV << '-f' << '-s' << '-t'
+    out, err = StringIO.new, StringIO.new
     assert_raises(SystemExit) {
-      _, err = capture_io { @app.run }
-      refute_match(/see full trace/, err)
+      rake_capture_io(out, err) { @app.run }
     }
+    err.rewind
+    refute_match(/See full trace/, err.read)
   ensure
     ARGV.clear
   end

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -338,7 +338,25 @@ class TestRakeApplication < Rake::TestCase
       rake_capture_io(out, err) { @app.run }
     }
     err.rewind
-    refute_match(/See full trace/, err.read)
+    err_s = err.read
+    refute_match(/See full trace/, err_s)
+    assert_match(/application.rb/, err_s)
+  ensure
+    ARGV.clear
+  end
+
+  def test_bad_run_with_cron
+    @app.intern(Rake::Task, "default").enhance { fail }
+    ARGV.clear
+    ARGV << '-f' << '-s' << '-c'
+    out, err = StringIO.new, StringIO.new
+    assert_raises(SystemExit) {
+      rake_capture_io(out, err) { @app.run }
+    }
+    err.rewind
+    err_s = err.read
+    refute_match(/See full trace/, err_s)
+    assert_match(/application.rb/, err_s)
   ensure
     ARGV.clear
   end

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -319,12 +319,10 @@ class TestRakeApplication < Rake::TestCase
     @app.intern(Rake::Task, "default").enhance { fail }
     ARGV.clear
     ARGV << '-f' << '-s' <<  '--rakelib=""'
-    out, err = StringIO.new, StringIO.new
-    assert_raises(SystemExit) {
-      rake_capture_io(out, err) { @app.run }
+    _, err = capture_io { 
+      assert_raises(SystemExit) { @app.run }
     }
-    err.rewind
-    assert_match(/See full trace/, err.read)
+    assert_match(/See full trace/, err)
   ensure
     ARGV.clear
   end
@@ -333,12 +331,10 @@ class TestRakeApplication < Rake::TestCase
     @app.intern(Rake::Task, "default").enhance { fail }
     ARGV.clear
     ARGV << '-f' << '-s' << '-t'
-    out, err = StringIO.new, StringIO.new
-    assert_raises(SystemExit) {
-      rake_capture_io(out, err) { @app.run }
+    _, err = capture_io { 
+      assert_raises(SystemExit) { @app.run }
     }
-    err.rewind
-    refute_match(/See full trace/, err.read)
+    refute_match(/See full trace/, err)
   ensure
     ARGV.clear
   end

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -239,6 +239,7 @@ class TestRakeApplicationOptions < Rake::TestCase
       flags('--cron', '-c') do |opts|
         assert opts.cron
         assert opts.silent
+        assert opts.ignore_deprecate
       end
     end
   end

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -234,6 +234,15 @@ class TestRakeApplicationOptions < Rake::TestCase
     end
   end
 
+  def test_cron
+    in_environment do
+      flags('--cron', '-c') do |opts|
+        assert opts.cron
+        assert opts.silent
+      end
+    end
+  end
+
   def test_trace_rules
     in_environment do
       flags('--rules') do |opts|


### PR DESCRIPTION
This option is like --silent except if there is an error it will print a full backtrace.

The motivation for this option is cronjobs. We get emails about cron tasks if there is any output at all, hence we use --silent to quiet rake down. But if a cronjob has failed (often overnight) you would like the email to contain as much information as possible about the error, so this prints backtraces.

BTW this relies on the previous pull request about tests to make it's tests work.
