### PR TITLE
Rake::TaskArguments should provide values_at for cleaner codezzz

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -43,6 +43,10 @@ module Rake
       @hash.each(&block)
     end
 
+    def values_at(*keys)
+      keys.map { |k| lookup(k) }
+    end
+
     def method_missing(sym, *args, &block)
       lookup(sym.to_sym)
     end

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -158,5 +158,13 @@ class TestRakeTaskWithArguments < Rake::TestCase
     t = task(:t  => [:pre])
     t.invoke("bill", "1.2")
   end
+
+  def test_values_at
+    t = task(:pre, [:a, :b, :c]) { |t, args|
+      a, b, c = args.values_at(:a, :b, :c)
+      assert_equal %w[1 2 3], [a, b, c]
+    }
+    t.invoke(*%w[1 2 3])
+  end
 end
 


### PR DESCRIPTION
Old:

```
task :ssh, [:env, :node] do |t, args|
  env, node = args[:env], args[:node]
  sh "eknife", env, "ssh", "hostname:#{node}", "interactive"
end
```

New:

```
task :ssh, [:env, :node] do |t, args|
  env, node = args.values_at(:env, :node)
  sh "eknife", env, "ssh", "hostname:#{node}", "interactive"
end
```

Thanks!
