### PR TITLE
Update version in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = RAKE -- Ruby Make
 
-Supporting Rake version: 0.8.7.
+Supporting Rake version: 0.9.2.
 
 This package contains Rake, a simple ruby build program with
 capabilities similar to make.


### PR DESCRIPTION
This should make http://rubydoc.info/gems/rake/0.9.2/frames (and maybe someday http://rake.rubyforge.org/) look like they apply to the current version.
