### PR TITLE
Option to remove Module#const_missing and DeprecatedObjectDSL

### DIFF
--- a/bin/rake
+++ b/bin/rake
@@ -28,6 +28,10 @@ begin
 rescue LoadError
 end
 
+module Rake
+  REDUCE_COMPAT = true if ARGV.include?("--reduce-compat")
+end
+
 require 'rake'
 
 Rake.application.run

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -349,6 +349,11 @@ module Rake
           # HACK Use File::PATH_SEPARATOR
           lambda { |value| options.rakelib = value.split(':') }
         ],
+        ['--reduce-compat', "Remove DSL in Object; remove Module#const_missing which defines ::Task etc.",
+          # Load-time option.
+          # Handled in bin/rake where Rake::REDUCE_COMPAT is defined (or not).
+          lambda { |_| }
+        ],
         ['--require', '-r MODULE', "Require MODULE before executing rakefile.",
           lambda { |value|
             begin

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -165,10 +165,10 @@ module Rake
         private :#{name}
       }, __FILE__, line
     end
-  end
+  end unless defined? Rake::REDUCE_COMPAT
 
   extend FileUtilsExt
 end
 
 self.extend Rake::DSL
-include Rake::DeprecatedObjectDSL
+include Rake::DeprecatedObjectDSL unless defined? Rake::REDUCE_COMPAT

--- a/lib/rake/ext/module.rb
+++ b/lib/rake/ext/module.rb
@@ -36,4 +36,4 @@ class Module
       rake_original_const_missing(const_name)
     end
   end
-end
+end unless defined? Rake::REDUCE_COMPAT

--- a/test/test_rake_reduce_compat.rb
+++ b/test/test_rake_reduce_compat.rb
@@ -1,0 +1,65 @@
+require File.expand_path('../helper', __FILE__)
+require 'open3'
+
+class TestRakeReduceCompat < Rake::TestCase
+  # TODO: factor out similar code in test_rake_functional.rb
+  def rake(*args)
+    lib = File.join(@orig_PWD, "lib")
+    bin_rake = File.join(@orig_PWD, "bin", "rake")
+    Open3.popen3(RUBY, "-I", lib, bin_rake, *args) { |_, out, _, _| out.read }
+  end
+  
+  def invoke_normal(task_name)
+    rake task_name.to_s
+  end
+
+  def invoke_reduce_compat(task_name)
+    rake "--reduce-compat", task_name.to_s
+  end
+
+  def test_no_deprecated_dsl
+    rakefile %q{
+      task :check_task do
+        Module.new { p defined?(task) }
+      end
+
+      task :check_file do
+        Module.new { p defined?(file) }
+      end
+    }
+    
+    assert_equal %{"method"}, invoke_normal(:check_task).chomp
+    assert_equal %{"method"}, invoke_normal(:check_file).chomp
+
+    assert_equal "nil", invoke_reduce_compat(:check_task).chomp
+    assert_equal "nil", invoke_reduce_compat(:check_file).chomp
+  end
+
+  def test_no_classic_namespace
+    rakefile %q{
+      task :check_task do
+        begin
+          Task
+          print "present"
+        rescue NameError
+          print "absent"
+        end
+      end
+
+      task :check_file_task do
+        begin
+          FileTask
+          print "present"
+        rescue NameError
+          print "absent"
+        end
+      end
+    }
+
+    assert_equal "present", invoke_normal(:check_task)
+    assert_equal "present", invoke_normal(:check_file_task)
+
+    assert_equal "absent", invoke_reduce_compat(:check_task)
+    assert_equal "absent", invoke_reduce_compat(:check_file_task)
+  end
+end


### PR DESCRIPTION
Fixes #7 and #55.

With <code>rake --reduce-compat</code>, Module#const_missing and the deprecated DSL in Object are removed entirely.
- Using the "classic namespace" -- <code>::Task</code> and friends -- will be an error, not a warning.
- <code>module Foo ; task :bar ; end</code> will be an error, not a warning.

The implementation uses a simple load-time constant since this is a temporary measure until these features are removed permanently (perhaps in Rake 1.0).

As a small bonus, <code>--reduce-compat</code> can serve as a convenient check before upgrading to the next incompatible Rake version.
