### PR TITLE
On error, show interesting portions of the backtrace by default

### DIFF
--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -58,6 +58,7 @@ require 'rake/early_time'
 require 'rake/name_space'
 require 'rake/task_manager'
 require 'rake/application'
+require 'rake/backtrace'
 
 $trace = false
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -149,7 +149,7 @@ module Rake
       if options.trace
         $stderr.puts ex.backtrace.join("\n")
       else
-        $stderr.puts rakefile_location(ex.backtrace)
+        $stderr.puts Backtrace.collapse(ex.backtrace)
       end
       $stderr.puts "Tasks: #{ex.chain}" if has_chain?(ex)
       $stderr.puts "(See full trace by running task with --trace)" unless options.trace

--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -1,0 +1,45 @@
+module Rake
+  module Backtrace
+    SUPPRESS_PATHS = [
+      RbConfig::CONFIG["prefix"],
+      File.join(File.dirname(__FILE__), ".."),
+    ]
+  
+    #
+    # Elide backtrace elements which match one of SUPPRESS_PATHS.
+    #
+    def self.collapse(backtrace)
+      paths = SUPPRESS_PATHS.map { |f| Regexp.quote File.expand_path(f) }
+  
+      # add bin/rake for rake testing
+      suppress_re = %r!(\A#{paths.join('|')}|bin/rake:\d+)!
+  
+      result = backtrace.map { |elem|
+        if elem =~ suppress_re
+          "[...suppressed backtrace...]"
+        else
+          elem
+        end
+      }
+  
+      remove_repeats(result)
+    end
+  
+    #
+    # Remove consecutive matches.
+    #
+    # remove_repeats [3, 3, 9, 3, 1, 1, 1, 4, 9, 9]  # => [3, 9, 3, 1, 4, 9]
+    #
+    def self.remove_repeats(array)
+      result = []
+      prev = nil
+      array.each_with_index do |elem, i|
+        if i == 0 or elem != prev
+          result << elem
+        end
+        prev = elem
+      end
+      result
+    end
+  end
+end

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -1,0 +1,52 @@
+require File.expand_path('../helper', __FILE__)
+require 'open3'
+
+class TestRakeBacktrace < Rake::TestCase
+  # TODO: factor out similar code in test_rake_functional.rb
+  def rake(*args)
+    lib = File.join(@orig_PWD, "lib")
+    bin_rake = File.join(@orig_PWD, "bin", "rake")
+    Open3.popen3(RUBY, "-I", lib, bin_rake, *args) { |_, _, err, _| err.read }
+  end
+  
+  def invoke(task_name)
+    rake task_name.to_s
+  end
+
+  def test_single_collapse
+    rakefile %q{
+      task :foo do
+        raise "foooo!"
+      end
+    }
+
+    lines = invoke(:foo).split("\n")
+
+    assert_equal "rake aborted!", lines[0]
+    assert_equal "foooo!", lines[1]
+    assert_match %r!\A#{Regexp.quote Dir.pwd}/Rakefile:3!, lines[2]
+    assert_equal "[...suppressed backtrace...]", lines[3]
+    assert_match %r!\ATasks:!, lines[4]
+  end
+
+  def test_multi_collapse
+    rakefile %q{
+      task :foo do
+        Rake.application.invoke_task(:bar)
+      end
+      task :bar do
+        raise "barrr!"
+      end
+    }
+
+    lines = invoke(:foo).split("\n")
+
+    assert_equal "rake aborted!", lines[0]
+    assert_equal "barrr!", lines[1]
+    assert_match %r!\A#{Regexp.quote Dir.pwd}/Rakefile:6!, lines[2]
+    assert_equal "[...suppressed backtrace...]", lines[3]
+    assert_match %r!\A#{Regexp.quote Dir.pwd}/Rakefile:3!, lines[4]
+    assert_equal "[...suppressed backtrace...]", lines[5]
+    assert_match %r!\ATasks:!, lines[6]
+  end
+end


### PR DESCRIPTION
I originally favored the idea of changing Rake to always show the backtrace on error. However when I tested this out I discovered why the default is to suppress.

Since Rake bugs are (we hope) relatively rare, almost all Rake errors are user errors. The backtrace contains a lot of uninteresting noise of Rake internals. Moreover when the full backtrace was shown by default, it suggested to me that an error in Rake was being reported, not my error.

My solution is a compromise: suppress backtrace lines from installed code and display everything else.

```
task :default do
  raise "ouch!"
end
```

Output without patch:

```
rake aborted!
ouch!

Tasks: TOP => default
(See full trace by running task with --trace)
```

Output with patch:

```
rake aborted!
ouch!
/path/to/Rakefile:2:in `block in <top (required)>'
[...suppressed backtrace...]
Tasks: TOP => default
(See full trace by running task with --trace)
```

Multiple portions may be elided while the interesting bits remain.

```
task :default do
  Rake.application.invoke_task :ouch
end

task :ouch do
  raise "ouch!"
end
```

Output without patch:

```
rake aborted!
ouch!

Tasks: TOP => ouch
(See full trace by running task with --trace)
```

Output with patch:

```
rake aborted!
ouch!
/path/to/Rakefile:6:in `block in <top (required)>'
[...suppressed backtrace...]
/path/to/Rakefile:2:in `block in <top (required)>'
[...suppressed backtrace...]
Tasks: TOP => default
(See full trace by running task with --trace)
```
