### PR TITLE
add --suppress-backtrace option

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -376,6 +376,11 @@ module Rake
             options.silent = true
           }
         ],
+        ['--suppress-backtrace PATTERN', "Suppress backtrace lines matching regexp PATTERN. Ignored if --trace is on.",
+          lambda { |value|
+            options.suppress_backtrace_pattern = Regexp.new(value)
+          }
+        ],
         ['--system',  '-g',
           "Using system wide (global) rakefiles (usually '~/.rake/*.rake').",
           lambda { |value| options.load_system = true }

--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -7,9 +7,10 @@ module Rake
 
     SUPPRESS_PATTERN = %r!(\A#{SUPPRESSED_PATHS.join('|')}|bin/rake:\d+)!
 
-    # Elide backtrace elements which match one of SUPPRESS_PATHS.
     def self.collapse(backtrace)
-      backtrace.reject { |elem| elem =~ SUPPRESS_PATTERN }
+      pattern = Rake.application.options.suppress_backtrace_pattern ||
+                SUPPRESS_PATTERN
+      backtrace.reject { |elem| elem =~ pattern }
     end
   end
 end

--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -1,9 +1,10 @@
 module Rake
   module Backtrace
-    SUPPRESSED_PATHS = [
-      RbConfig::CONFIG["prefix"],
-      File.join(File.dirname(__FILE__), ".."),
-    ].map { |f| Regexp.quote(File.expand_path(f)) }
+    SUPPRESSED_PATHS =
+      RbConfig::CONFIG.values_at(*RbConfig::CONFIG.
+                                 keys.grep(/(prefix|libdir)/)) + [
+        File.join(File.dirname(__FILE__), ".."),
+      ].map { |f| Regexp.quote(File.expand_path(f)) }
 
     SUPPRESS_PATTERN = %r!(\A#{SUPPRESSED_PATHS.join('|')}|bin/rake:\d+)!
 

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -46,4 +46,22 @@ class TestRakeBacktrace < Rake::TestCase
     assert_match %r!\A#{Regexp.quote Dir.pwd}/Rakefile:3!, lines[3]
     assert_match %r!\ATasks:!, lines[4]
   end
+
+  def test_suppress_option
+    rakefile %q{
+      task :baz do
+        raise "bazzz!"
+      end
+    }
+
+    lines = rake("baz").split("\n")
+    assert_equal "rake aborted!", lines[0]
+    assert_equal "bazzz!", lines[1]
+    assert_match %r!Rakefile!, lines[2]
+
+    lines = rake("--suppress-backtrace", "R.k.file", "baz").split("\n")
+    assert_equal "rake aborted!", lines[0]
+    assert_equal "bazzz!", lines[1]
+    refute_match %r!Rakefile!, lines[2]
+  end
 end


### PR DESCRIPTION
The original commit in #64 allowed the user to add paths to SUPPRESS_PATHS in case of annoyance. For instance if gems are not installed under CONFIG['prefix'] then this would have the effect of --trace being permanently on.

That flexibility was removed in the final commit. I've added it back with a command-line option this time, and using a regexp instead of a list of paths.

If you decide against the option then I would recommend at least having <code>Rake.application.options.suppress_backtrace_pattern</code> available in code, or some other escape hatch.
