### PR TITLE
allows tasks access to extra (unnamed) task arguments

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -15,8 +15,9 @@ module Rake
       @names = names
       @parent = parent
       @hash = {}
-      names.each_with_index { |name, i|
-        @hash[name.to_sym] = values[i] unless values[i].nil?
+      values.each_with_index { |val, i|
+        name = (names[i] || "_arg_%03d_" % i).to_sym
+        @hash[name] = val unless val.nil?
       }
     end
 

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -52,6 +52,11 @@ class TestRakeTaskWithArguments < Rake::TestCase
 
   def test_arg_list_is_empty_if_no_args_given
     t = task(:t) { |tt, args| assert_equal({}, args.to_hash) }
+    t.invoke()
+  end
+
+  def test_arg_list_contains_extra_args
+    t = task(:t) { |tt, args| assert_equal({:_arg_000_ => 1, :_arg_001_ => 2, :_arg_002_ => 3}, args.to_hash) }
     t.invoke(1, 2, 3)
   end
 


### PR DESCRIPTION
Pros:
- This lets rake tasks use varargs-style parameters.
- This is useful for passing in lists, as well as handling string params containing commas.

Possible Issues:
- If a task is currently iterating through the args, and the task is called with additional arguments,
  then this could break an existing task. Calling the rake task with unnamed arguments was previously
  incorrect usage, however.
- If someone names their params like _arg_001_ then unnamed params will overwrite the value.
  Naming args like that, however, is pretty bad practice.
