### PR TITLE
Avoid hardcoded newline tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -81,6 +81,10 @@ class Rake::TestCase < MiniTest::Unit::TestCase
     Rake.application.options.ignore_deprecate = false
   end
 
+  def new_line
+    Rake.application.windows? ? "\r\n" : "\n"
+  end
+
   def rake_system_dir
     @system_dir = 'system'
 

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -342,7 +342,7 @@ class TestRakeFileList < Rake::TestCase
       files.egrep(/XYZZY/)
     end
 
-    assert_equal "xyzzy.txt:2:XYZZY\n", out
+    assert_equal "xyzzy.txt:2:XYZZY#{new_line}", out
   end
 
   def test_egrep_with_block
@@ -353,7 +353,7 @@ class TestRakeFileList < Rake::TestCase
       found = [fn, ln, line]
     end
 
-    assert_equal ["xyzzy.txt", 2, "XYZZY\n"], found
+    assert_equal ["xyzzy.txt", 2, "XYZZY#{new_line}"], found
   end
 
   def test_egrep_with_error


### PR DESCRIPTION
Add `new_line` helper to avoid usage of hardcoded newline evaluation in
tests.

Correct tests that presented this issue.

All tests pass:

```
ruby 1.9.3dev (2011-09-02 revision 33165) [i386-mingw32]
437 tests, 1250 assertions, 0 failures, 0 errors, 0 skips
```
