### PR TITLE
FileLists play nicely with Pathname objects

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -101,8 +101,7 @@ http://github.com/jimweirich/rake. The public git clone URL is
 
 If you wish to run the unit and functional tests that come with Rake:
 
-* Install the 'flexmock' gem
-* Install the 'session' gem in order to run the functional tests.
+* If you are not on Ruby 1.9, install the 'minitest' gem.
 * CD into the top project directory of rake.
 * Type one of the following:
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,7 @@ rescue Gem::LoadError
 end
 
 require 'minitest/autorun'
+require 'pathname'
 require 'rake'
 require 'tmpdir'
 require File.expand_path('../file_creation', __FILE__)


### PR DESCRIPTION
`Pathname`'s philosophy of using string manipulation whenever possible is a nice complement to `FileList`'s lazy evaluation. Since `File` methods, `Dir.glob`, etc. are generally `to_path`-aware for Ruby 1.9, many parts of `FileList` just work in 1.8 and 1.9, so long as some care is taken for string and regex operations.

I first ran into this shortcoming with `rake/clean` when attempting to `CLOBBER.include` a `Pathname` object, and it blew up on a regex comparison. The convenience of `Pathname` makes it useful for many general cases with Rake though, I think. 

There may be a better way to achieve this, and it may not be exhaustive. I'm happy to add more explicit tests, but I thought I'd seek your opinion on the direction of it before going further.
