### PR TITLE
ignore nil values passed to sh() and ruby()

### DIFF
--- a/lib/rake/alt_system.rb
+++ b/lib/rake/alt_system.rb
@@ -82,6 +82,7 @@ module Rake::AltSystem
     end
 
     def system(cmd, *args)
+      args.compact!
       repaired = (
         if args.empty?
           [repair_command(cmd)]

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -141,6 +141,12 @@ class TestRakeFileUtils < Rake::TestCase
     }
   end
 
+  def test_sh_with_nil_arguments
+    verbose(false) {
+      Sh.run RUBY, nil, nil, nil, '-e', nil, 'true', nil, nil, nil, nil, nil
+    }
+  end
+
   def test_sh_failure
     shellcommand
 
@@ -238,6 +244,12 @@ class TestRakeFileUtils < Rake::TestCase
       replace_ruby {
         ruby 'check_no_expansion.rb', env_var, 'someval'
       }
+    }
+  end
+
+  def test_ruby_with_nil_arguments
+    verbose(false) {
+      ruby nil, nil, nil, '-e', nil, 'true', nil, nil, nil, nil, nil
     }
   end
 


### PR DESCRIPTION
This patch allows you to pass nil values to Rake's sh() and ruby()
methods.  This is useful when you want to conditionally pass arguments
to the child program you are executing.

For example, suppose you want to pass `-v` to a child program if the
user ran Rake in tracing mode (`rake --trace`), but not otherwise:

``` ruby
sh 'asciidoc', ('-v' if Rake.application.options.trace), 'input.txt'
```

Without this patch, you have to carefully construct an arguments array
so that it does not contain nil values:

``` ruby
args = []
args << '-v' if Rake.application.options.trace
args << 'input.txt'
sh 'asciidoc', *args
```

Sadly, this becomes very tiresome when performed more than a few times.

See http://redmine.ruby-lang.org/issues/3631 for more information.
