### PR TITLE
Direct banner output to STDOUT when using --trace option

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -150,7 +150,7 @@ module Rake
       new_chain = InvocationChain.append(self, invocation_chain)
       @lock.synchronize do
         if application.options.trace
-          $stderr.puts "** Invoke #{name} #{format_trace_flags}"
+          $stdout.puts "** Invoke #{name} #{format_trace_flags}"
         end
         return if @already_invoked
         @already_invoked = true
@@ -194,7 +194,7 @@ module Rake
         return
       end
       if application.options.trace
-        $stderr.puts "** Execute #{name}"
+        $stdout.puts "** Execute #{name}"
       end
       application.enhance_with_matching_rule(name) if @actions.empty?
       @actions.each do |act|


### PR DESCRIPTION
This is useful when using a rake as a cronjob. The use case is being able to redirect stdout to never-never-land (/dev/null), but allow stderr to pass through, which could then get emailed to the postmaster.

The suggestion is to keep boilerplate output to stdout, and actual errors to stderr.
