### PR TITLE
Remove an unused block argument to avoid creating Proc objects.

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -47,7 +47,7 @@ module Rake
       keys.map { |k| lookup(k) }
     end
 
-    def method_missing(sym, *args, &block)
+    def method_missing(sym, *args)
       lookup(sym.to_sym)
     end
 


### PR DESCRIPTION
I propose that an unused block argument should be removed.
It creates unnecessary Proc objects.

I applied similar patches to standard libraries in ruby-trunk(ruby/ruby@c3749b6).

Thanks
