### PR TITLE
Rake::FileList#egrep: don't open files in binary mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
 * Commands constant is no longer polluting top level namespace.
 * Show only the interesting portion of the backtrace by default (James M. Lawrence).
 * Added --reduce-compat optiont to remove backward compatible DSL hacks (James M. Lawrence).
+* lib/rake/file_list.rb (Rake::FileList#egrep): there is no need to
+  open files in binary mode. (NAKAMURA Usaku)
 
 == Version 0.9.2
 

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -286,7 +286,7 @@ module Rake
       matched = 0
       each do |fn|
         begin
-          open(fn, "rb", *options) do |inf|
+          open(fn, "r:ascii-8bit", *options) do |inf|
             count = 0
             inf.each do |line|
               count += 1


### PR DESCRIPTION
This fixes the egrep tests in `test_rake_file_list` on Windows.

See also:
- https://github.com/jimweirich/rake/issues/74
- https://github.com/jimweirich/rake/pull/72
