### PR TITLE
make directory tasks handle both "a/" and "a"

### DIFF
--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -64,9 +64,12 @@ module Rake
     #
     def directory(dir)
       Rake.each_dir_parent(dir) do |d|
+        # append slash if no trailing slash; otherwise, strip it
+        d_alias = d[-1] == ?/ ? d[0...-1] : d + ?/
+
         file_create d do |t|
           mkdir_p t.name if ! File.exist?(t.name)
-        end
+        end.alias_task(d_alias)
       end
     end
 

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -89,6 +89,12 @@ module Rake
       self
     end
 
+    # Aliases +other_task_name+ so that lookups for it result in this
+    # task being returned.
+    def alias_task(other_task_name)
+      application.alias_task(other_task_name, name)
+    end
+
     # Name of the task, including any namespace qualifiers.
     def name
       @name.to_s

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -34,6 +34,10 @@ module Rake
       task.enhance(deps, &block)
     end
 
+    def alias_task(other_task_name, task_name)
+      @tasks[other_task_name.to_s] = @tasks[task_name.to_s]
+    end
+
     # Lookup a task.  Return an existing task if found, otherwise
     # create a task of the current type.
     def intern(task_class, task_name)

--- a/test/test_rake_directory_task.rb
+++ b/test/test_rake_directory_task.rb
@@ -27,20 +27,26 @@ class TestRakeDirectoryTask < Rake::TestCase
 
   if Rake::Win32.windows?
     def test_directory_win32
+      drive = Dir.pwd
+      while drive != File.dirname(drive)
+        drive = File.dirname(drive)
+      end
+      drive = drive[0...-1] if drive[-1] == ?/
+
       desc "WIN32 DESC"
-      directory 'c:/a/b/c'
-      assert_equal FileTask, Task['c:'].class
-      assert_equal FileCreationTask, Task['c:/a'].class
-      assert_equal FileCreationTask, Task['c:/a/b'].class
-      assert_equal FileCreationTask, Task['c:/a/b/c'].class
-      assert_nil             Task['c:/'].comment
-      assert_equal "WIN32 DESC",   Task['c:/a/b/c'].comment
-      assert_nil             Task['c:/a/b'].comment
+      directory File.join(Dir.pwd, 'a/b/c')
+      assert_equal FileTask, Task[drive].class if drive[-1] == ?:
+      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a')].class
+      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a/b')].class
+      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a/b/c')].class
+      assert_nil             Task[drive].comment
+      assert_equal "WIN32 DESC",   Task[File.join(Dir.pwd, 'a/b/c')].comment
+      assert_nil             Task[File.join(Dir.pwd, 'a/b')].comment
       verbose(false) {
-        Task['c:/a/b'].invoke
+        Task[File.join(Dir.pwd, 'a/b')].invoke
       }
-      assert File.exist?('c:/a/b')
-      refute File.exist?('c:/a/b/c')
+      assert File.exist?(File.join(Dir.pwd, 'a/b'))
+      refute File.exist?(File.join(Dir.pwd, 'a/b/c'))
     end
   end
 end

--- a/test/test_rake_directory_task.rb
+++ b/test/test_rake_directory_task.rb
@@ -44,34 +44,4 @@ class TestRakeDirectoryTask < Rake::TestCase
     refute_instance_of Rake::FileTask,         Task["a"]
     assert_instance_of Rake::FileCreationTask, Task["a"]
   end
-
-  if Rake::Win32.windows?
-    def test_directory_win32
-      drive = Dir.pwd
-      while drive != File.dirname(drive)
-        drive = File.dirname(drive)
-      end
-      drive = drive[0...-1] if drive[-1] == ?/
-
-      desc "WIN32 DESC"
-      directory File.join(Dir.pwd, 'a/b/c')
-
-      if drive[-1] == ?:
-        assert_equal FileTask, Task[drive].class
-        assert_equal FileCreationTask, Task[drive + ?/].class
-      end
-
-      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a')].class
-      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a/b')].class
-      assert_equal FileCreationTask, Task[File.join(Dir.pwd, 'a/b/c')].class
-      assert_nil             Task[drive].comment
-      assert_equal "WIN32 DESC",   Task[File.join(Dir.pwd, 'a/b/c')].comment
-      assert_nil             Task[File.join(Dir.pwd, 'a/b')].comment
-      verbose(false) {
-        Task[File.join(Dir.pwd, 'a/b')].invoke
-      }
-      assert File.exist?(File.join(Dir.pwd, 'a/b'))
-      refute File.exist?(File.join(Dir.pwd, 'a/b/c'))
-    end
-  end
 end

--- a/test/test_rake_file_creation_task.rb
+++ b/test/test_rake_file_creation_task.rb
@@ -25,13 +25,6 @@ class TestRakeFileCreationTask < Rake::TestCase
     assert ! fc_task.needed?, "file should not be needed"
   end
 
-  def test_directory
-    directory DUMMY_DIR
-    fc_task = Task[DUMMY_DIR]
-    assert_equal DUMMY_DIR, fc_task.name
-    assert FileCreationTask === fc_task
-  end
-
   def test_no_retriggers_on_filecreate_task
     create_timed_files(OLDFILE, NEWFILE)
     t1 = Rake.application.intern(FileCreationTask, OLDFILE).enhance([NEWFILE])


### PR DESCRIPTION
That way, if you write

```
directory "a/b"
```

both `Task["a/"]` and `Task["a"]` will be handled as the same `FileCreationTask`s.

Some fixes and cleanups are included too.
