### PR TITLE
Fix incorrect line reported for rdoctask deprecation

### DIFF
--- a/lib/rake/rdoctask.rb
+++ b/lib/rake/rdoctask.rb
@@ -1,7 +1,7 @@
 # rake/rdoctask is deprecated in favor of rdoc/task
 
 if Rake.application
-  Rake.application.deprecate('require \'rake/rdoctask\'', 'require \'rdoc/task\' (in RDoc 2.4.2+)', __FILE__)
+  Rake.application.deprecate('require \'rake/rdoctask\'', 'require \'rdoc/task\' (in RDoc 2.4.2+)', caller.first)
 end
 
 require 'rubygems'


### PR DESCRIPTION
By using **FILE**, the actual line for the deprecate will be reported as the source of the deprecation.
