### PR TITLE
Add default for deprecate call site

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -160,7 +160,7 @@ module Rake
     # Example:
     #    Rake.application.deprecate("import", "Rake.import", caller.first)
     #
-    def deprecate(old_usage, new_usage, call_site)
+    def deprecate(old_usage, new_usage, call_site = caller[1])
       return if options.ignore_deprecate
       $stderr.puts "WARNING: '#{old_usage}' is deprecated.  " +
         "Please use '#{new_usage}' instead.\n" +

--- a/lib/rake/rdoctask.rb
+++ b/lib/rake/rdoctask.rb
@@ -1,7 +1,7 @@
 # rake/rdoctask is deprecated in favor of rdoc/task
 
 if Rake.application
-  Rake.application.deprecate('require \'rake/rdoctask\'', 'require \'rdoc/task\' (in RDoc 2.4.2+)', __FILE__)
+  Rake.application.deprecate('require \'rake/rdoctask\'', 'require \'rdoc/task\' (in RDoc 2.4.2+)')
 end
 
 require 'rubygems'


### PR DESCRIPTION
I made a simpler fix for this using the github editor just a few minutes ago in the branch patch-1. But then I figured it would be better to solve the problem by making caller[1] the default value. This won't always work, but it should avoid mistakes like using **FILE** for the most common cases where caller.first is the right parameter.
