### PR TITLE
Move object copying code to initialize_copy method.

### DIFF
--- a/lib/rake/cloneable.rb
+++ b/lib/rake/cloneable.rb
@@ -3,23 +3,14 @@ module Rake
   # Mixin for creating easily cloned objects.
   #
   module Cloneable
-    # Clone an object by making a new object and setting all the instance
-    # variables to the same values.
-    def dup
-      sibling = self.class.new
-      instance_variables.each do |ivar|
-        value = self.instance_variable_get(ivar)
-        new_value = value.clone rescue value
-        sibling.instance_variable_set(ivar, new_value)
+    # The hook that invoked by 'clone' and 'dup' methods.
+    def initialize_copy(source)
+      super
+      source.instance_variables.each do |var|
+        src_value  = source.instance_variable_get(var)
+        value = src_value.clone rescue src_value
+        instance_variable_set(var, value)
       end
-      sibling.taint if tainted?
-      sibling
-    end
-
-    def clone
-      sibling = dup
-      sibling.freeze if frozen?
-      sibling
     end
   end
 end


### PR DESCRIPTION
Maybe it looks some better instead of 'clone' and 'dup' re-definition.
