### PR TITLE
Add '--include-hidden-tasks' option to enhance '-T' and '-D'

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -206,7 +206,7 @@ module Rake
     # Display the tasks and comments.
     def display_tasks_and_comments
       displayable_tasks = tasks.select { |t|
-        t.comment && t.name =~ options.show_task_pattern
+        options.include_hidden_tasks || (t.comment && (t.name =~ options.show_task_pattern))
       }
       case options.show_tasks
       when :tasks
@@ -220,7 +220,7 @@ module Rake
       when :describe
         displayable_tasks.each do |t|
           puts "#{name} #{t.name_with_args}"
-          t.full_comment.split("\n").each do |line|
+          t.full_comment.to_s.split("\n").each do |line|
             puts "    #{line}"
           end
           puts
@@ -269,6 +269,7 @@ module Rake
     end
 
     def truncate(string, width)
+      string = string.to_s
       if string.length <= width
         string
       else
@@ -324,6 +325,11 @@ module Rake
         ['--execute-continue',  '-E CODE',
           "Execute some Ruby code, then continue with normal task processing.",
           lambda { |value| eval(value) }
+        ],
+          ['--include-hidden-tasks', "Include tasks without descriptions when displaying or describing tasks.",
+          lambda { |value|
+            options.include_hidden_tasks = true
+          }
         ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -93,6 +93,20 @@ class TestRakeApplication < Rake::TestCase
     assert_match(/# 12345678901234567890123456789012345678901234567890123456789012345\.\.\./, out)
   end
 
+  def test_display_all_tasks
+    @app.options.show_tasks = :tasks
+    @app.options.include_hidden_tasks = true
+    @app.options.show_task_pattern = //
+    @app.last_description = "COMMENT"
+    @app.define_task(Rake::Task, "t")
+    @app.last_description = nil
+    @app.define_task(Rake::Task, "h")
+    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    assert_match(/^rake t/, out)
+    assert_match(/# COMMENT/, out)
+    assert_match(/^rake h/, out)
+  end
+
   def test_describe_tasks
     @app.options.show_tasks = :describe
     @app.options.show_task_pattern = //
@@ -101,6 +115,20 @@ class TestRakeApplication < Rake::TestCase
     out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
     assert_match(/^rake t$/, out)
     assert_match(/^ {4}COMMENT$/, out)
+  end
+
+  def test_describe_all_tasks
+    @app.options.show_tasks = :describe
+    @app.options.include_hidden_tasks = true
+    @app.options.show_task_pattern = //
+    @app.last_description = "COMMENT"
+    @app.define_task(Rake::Task, "t")
+    @app.last_description = nil
+    @app.define_task(Rake::Task, "h")
+    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    assert_match(/^rake t$/, out)
+    assert_match(/^ {4}COMMENT$/, out)
+    assert_match(/^rake h$/, out)
   end
 
   def test_show_lines

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -220,6 +220,12 @@ class TestRakeApplicationOptions < Rake::TestCase
     end
   end
 
+  def test_include_hidden_tasks
+    flags('--include-hidden-tasks') do |opts|
+      assert_equal true, opts.include_hidden_tasks
+    end
+  end
+
   def test_where
     flags('--where', '-W') do |opts|
       assert_equal :lines, opts.show_tasks


### PR DESCRIPTION
Since we can invoke tasks that do not have descriptions, we ought to be able to display and describe them, too.

The [Cape](http://github.com/njonsson/cape) project would really benefit from this feature, since Cape uses shell integration to enumerate Rake tasks. (Why does Cape resort to shell integration instead of calling the Rake API? Because Cape provides Capistrano-to-Rake integration, and must therefore run under the auspices of Capistrano, whose DSL treads on Rake’s toes.)

The new `--include-hidden-tasks` command-line option has no effect by itself. But when it is specified together with `-T` (`--tasks`) or `-D` (`--describe`), it causes Rake to display tasks that lack descriptions as well as those that have descriptions.
