### PR TITLE
Reevaluate task prerequisites if they change. 

### DIFF
--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -11,7 +11,7 @@ module Rake
         Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
       }
       threads.each { |t| t.join }
-      invoke_prerequisites(task_args, invocation_chain) if prerequisite_tasks.size != original_size
+      invoke_prerequisites(args, invocation_chain) if prerequisite_tasks.size != original_size
     end
   end
 

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -5,11 +5,6 @@ module Rake
   #
   class MultiTask < Task
     private
-    def invoke_prerequisites(args, invocation_chain)
-      original=prerequisite_tasks.dup
-      invoke_prerequisite_list(prerequisite_tasks,args,invocation_chain)
-      invoke_prerequisite_list(prerequisite_tasks-original,args,invocation_chain)
-    end
     def invoke_prerequisite_list prereqs,args,invocation_chain
       threads = prereqs.collect { |p|
         Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -6,13 +6,15 @@ module Rake
   class MultiTask < Task
     private
     def invoke_prerequisites(args, invocation_chain)
-      original_size=prerequisite_tasks.size
-      threads = @prerequisites.collect { |p|
+      original=prerequisite_tasks.dup
+      invoke_prerequisite_list(prerequisite_tasks,args,invocation_chain)
+      invoke_prerequisite_list(prerequisite_tasks-original,args,invocation_chain)
+    end
+    def invoke_prerequisite_list prereqs,args,invocation_chain
+      threads = prereqs.collect { |p|
         Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
       }
       threads.each { |t| t.join }
-      invoke_prerequisites(args, invocation_chain) if prerequisite_tasks.size != original_size
     end
   end
-
 end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -6,10 +6,12 @@ module Rake
   class MultiTask < Task
     private
     def invoke_prerequisites(args, invocation_chain)
+      original_size=prerequisite_tasks.size
       threads = @prerequisites.collect { |p|
         Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
       }
       threads.each { |t| t.join }
+      invoke_prerequisites(task_args, invocation_chain) if prerequisite_tasks.size != original_size
     end
   end
 

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -171,14 +171,18 @@ module Rake
 
     # Invoke all the prerequisites of a task.
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
-      original_size=prerequisite_tasks.size
-      prerequisite_tasks.each { |prereq|
+      original=prerequisite_tasks.dup
+      invoke_prerequisite_list(prerequisite_tasks,task_args,invocation_chain)
+      invoke_prerequisite_list(prerequisite_tasks-original,task_args,invocation_chain)
+    end
+    
+    def invoke_prerequisite_list prereqs,task_args,invocation_chain
+      prereqs.each { |prereq|
         prereq_args = task_args.new_scope(prereq.arg_names)
         prereq.invoke_with_call_chain(prereq_args, invocation_chain)
       }
-      invoke_prerequisites(task_args, invocation_chain) if prerequisite_tasks.size != original_size
     end
-
+    private :invoke_prerequisite_list
     # Format the trace flags for display.
     def format_trace_flags
       flags = []

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -171,10 +171,12 @@ module Rake
 
     # Invoke all the prerequisites of a task.
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
+      original_size=prerequisite_tasks.size
       prerequisite_tasks.each { |prereq|
         prereq_args = task_args.new_scope(prereq.arg_names)
         prereq.invoke_with_call_chain(prereq_args, invocation_chain)
       }
+      invoke_prerequisites(task_args, invocation_chain) if prerequisite_tasks.size != original_size
     end
 
     # Format the trace flags for display.

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -170,12 +170,20 @@ module Rake
     private :add_chain_to
 
     # Invoke all the prerequisites of a task.
+    #
+    # Re-evaluates the prerequisite list after each run through to
+    #check if prerequisites have been added and invokes the additions
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
-      original=prerequisite_tasks.dup
+      initial_prereqs=prerequisite_tasks.dup
       invoke_prerequisite_list(prerequisite_tasks,task_args,invocation_chain)
-      invoke_prerequisite_list(prerequisite_tasks-original,task_args,invocation_chain)
+      prereqs_to_invoke=prerequisite_tasks-initial_prereqs
+      while !(prereqs_to_invoke).empty?
+        initial_prereqs=prerequisite_tasks.dup
+        invoke_prerequisite_list(prereqs_to_invoke,task_args,invocation_chain)
+        prereqs_to_invoke=prerequisite_tasks-initial_prereqs
+      end
     end
-    
+
     def invoke_prerequisite_list prereqs,task_args,invocation_chain
       prereqs.each { |prereq|
         prereq_args = task_args.new_scope(prereq.arg_names)

--- a/test/test_rake_multi_task.rb
+++ b/test/test_rake_multi_task.rb
@@ -50,22 +50,27 @@ class TestRakeMultiTask < Rake::TestCase
   
   #Test the handling of prerequisite invocation when the list 
   #of prerequisites for a task is changed by a prerequisite
-  def test_dynamic_prerequisites
-    runlist = []
-    t1 = multitask(:t1 => [:t2]) { |t| runlist << t.name; 3321 }
-    t2 = multitask(:t2) { |t| task :t1=>:t3; runlist << t.name }
-    #although it adds a prerequisite to t2 it will do so after t2 is executed
-    t3 = multitask(:t3) { |t| task :t2=>:t4; runlist << t.name }
-    t4 = multitask(:t4) { |t| runlist << t.name }
-    assert_equal ["t2"], t1.prerequisites
-    assert_equal [], t2.prerequisites
-    t1.invoke
-    assert_equal ["t2","t3"], t1.prerequisites
-    #so, these have changed but not in time
-    #so you can't change prereqs on the same level
-    assert_equal ["t4"], t2.prerequisites
-    #but changing the prereqs of the "parent" works
-    assert_equal ["t2", "t3", "t1"], runlist
-  end
+  def test_multitask_dynamic_prerequisites
+     runlist = []
+     #t1 depends on t2
+     t1 = multitask(:t1 => [:t2]) { |t| runlist << t.name; 3321 }
+     #t2 adds t3 to the t1 dependencies
+     t2 = task(:t2) { |t| task :t1=>:t3; runlist << t.name }
+     #t3 adds t4 to t2 and t5 to t1
+     #although it adds a prerequisite to t2 it will do so after t2 is executed
+     #so it should be ivnoked. t5 on the other hand should
+     t3 = task(:t3) { |t| task :t2=>:t4; task :t1=>:t5; runlist << t.name }
+     t4 = task(:t4) { |t| runlist << t.name }
+     t5 = task(:t5) { |t| runlist << t.name }
+     assert_equal ["t2"], t1.prerequisites
+     assert_equal [], t2.prerequisites
+     t1.invoke
+     assert_equal ["t2","t3","t5"], t1.prerequisites
+     #so, these have changed but not in time
+     #so you can't change prereqs on the same level
+     assert_equal ["t4"], t2.prerequisites
+     #but changing the prereqs of the "parent" works
+     assert_equal ["t2", "t3", "t5","t1"], runlist
+   end
 end
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -207,20 +207,26 @@ class TestRakeTask < Rake::TestCase
   #of prerequisites for a task is changed by a prerequisite
   def test_dynamic_prerequisites
     runlist = []
+
+    #t1 depends on t2
     t1 = task(:t1 => [:t2]) { |t| runlist << t.name; 3321 }
+    #t2 adds t3 to the t1 dependencies
     t2 = task(:t2) { |t| task :t1=>:t3; runlist << t.name }
+    #t3 adds t4 to t2 and t5 to t1
     #although it adds a prerequisite to t2 it will do so after t2 is executed
-    t3 = task(:t3) { |t| task :t2=>:t4; runlist << t.name }
+    #so it should be ivnoked. t5 on the other hand should
+    t3 = task(:t3) { |t| task :t2=>:t4; task :t1=>:t5; runlist << t.name }
     t4 = task(:t4) { |t| runlist << t.name }
+    t5 = task(:t5) { |t| runlist << t.name }
     assert_equal ["t2"], t1.prerequisites
     assert_equal [], t2.prerequisites
     t1.invoke
-    assert_equal ["t2","t3"], t1.prerequisites
+    assert_equal ["t2","t3","t5"], t1.prerequisites
     #so, these have changed but not in time
     #so you can't change prereqs on the same level
     assert_equal ["t4"], t2.prerequisites
     #but changing the prereqs of the "parent" works
-    assert_equal ["t2", "t3", "t1"], runlist
+    assert_equal ["t2", "t3", "t5","t1"], runlist	
   end
   
   def test_timestamp_returns_now_if_all_prereqs_have_no_times

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -202,7 +202,27 @@ class TestRakeTask < Rake::TestCase
 
     assert_equal [b, c], a.prerequisite_tasks
   end
-
+  
+  #Test the handling of prerequisite invocation when the list 
+  #of prerequisites for a task is changed by a prerequisite
+  def test_dynamic_prerequisites
+    runlist = []
+    t1 = task(:t1 => [:t2]) { |t| runlist << t.name; 3321 }
+    t2 = task(:t2) { |t| task :t1=>:t3; runlist << t.name }
+    #although it adds a prerequisite to t2 it will do so after t2 is executed
+    t3 = task(:t3) { |t| task :t2=>:t4; runlist << t.name }
+    t4 = task(:t4) { |t| runlist << t.name }
+    assert_equal ["t2"], t1.prerequisites
+    assert_equal [], t2.prerequisites
+    t1.invoke
+    assert_equal ["t2","t3"], t1.prerequisites
+    #so, these have changed but not in time
+    #so you can't change prereqs on the same level
+    assert_equal ["t4"], t2.prerequisites
+    #but changing the prereqs of the "parent" works
+    assert_equal ["t2", "t3", "t1"], runlist
+  end
+  
   def test_timestamp_returns_now_if_all_prereqs_have_no_times
     a = task :a => ["b", "c"]
     b = task :b


### PR DESCRIPTION
This allows a prerequisite to add additional prereqs to it's parent task.

For a bit more blurb see http://ampelofilosofies.gr/software/2012/01/13/rake-dynamic-prerequisites/

This will cut my current rakefile size down by a good 1/4. I'll have to run some benchmarks to see how much faster the startup times get.
