### PR TITLE
Add --backtrace option to see backtrace without seing the trace.

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -146,13 +146,14 @@ module Rake
     def display_error_message(ex)
       $stderr.puts "#{name} aborted!"
       $stderr.puts ex.message
-      if options.trace
+      show_trace = options.trace || options.backtrace
+      if show_trace
         $stderr.puts ex.backtrace.join("\n")
       else
         $stderr.puts Backtrace.collapse(ex.backtrace)
       end
       $stderr.puts "Tasks: #{ex.chain}" if has_chain?(ex)
-      $stderr.puts "(See full trace by running task with --trace)" unless options.trace
+      $stderr.puts "(See full trace by running task with --trace)" unless show_trace
     end
 
     # Warn about deprecated usage.
@@ -288,6 +289,11 @@ module Rake
     # passing to OptionParser.
     def standard_rake_options
       [
+        ['--backtrace', "Enable full backtrace.",
+          lambda { |value|
+            options.backtrace = true
+          }
+        ],
         ['--classic-namespace', '-C', "Put Task and FileTask in the top level namespace",
           lambda { |value|
             require 'rake/classic_namespace'

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -385,6 +385,18 @@ class TestRakeApplication < Rake::TestCase
     ARGV.clear
   end
 
+  def test_bad_run_with_backtrace
+    @app.intern(Rake::Task, "default").enhance { fail }
+    ARGV.clear
+    ARGV << '-f' << '-s' << '--backtrace'
+    assert_raises(SystemExit) {
+      _, err = capture_io { @app.run }
+      refute_match(/see full trace/, err)
+    }
+  ensure
+    ARGV.clear
+  end
+
   def test_run_with_bad_options
     @app.intern(Rake::Task, "default").enhance { fail }
     ARGV.clear

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -29,6 +29,7 @@ class TestRakeApplicationOptions < Rake::TestCase
 
   def test_default_options
     opts = command_line
+    assert_nil opts.backtrace
     assert_nil opts.classic_namespace
     assert_nil opts.dryrun
     assert_nil opts.ignore_system
@@ -200,6 +201,13 @@ class TestRakeApplicationOptions < Rake::TestCase
       assert opts.trace
       assert Rake::FileUtilsExt.verbose_flag
       assert ! Rake::FileUtilsExt.nowrite_flag
+    end
+  end
+
+  def test_backtrace
+    flags('--backtrace') do |opts|
+      assert opts.backtrace
+      assert ! Rake::FileUtilsExt.verbose_flag
     end
   end
 


### PR DESCRIPTION
It is then possible to have backtrace turned on all the time,
e.g. no re-running of failed tasks is necessary, without cluttering the output of successful rake tasks.
