### PR TITLE
Add support for --jobs NUMBER  (or -j) 

### DIFF
--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -31,11 +31,19 @@ Options are:
 [<tt>--execute-print</tt> _code_ (-p)]
     Execute some Ruby code, print the result, and exit.
 
-[<tt>--execute-continue</tt> _code_ (-p)]
+[<tt>--execute-continue</tt> _code_ (-E)]
     Execute some Ruby code, then continue with normal task processing.
 
 [<tt>--help</tt>  (-H)]
     Display some help text and exit.
+
+[<tt>--jobs</tt> _number_  (-j)]
+    Specifies the maximum number of concurrent tasks. The suggested
+    value is equal to the number of CPUs.
+    
+    Sample values:
+     default: unlimited concurrent tasks (standard rake behavior)
+     1: one task at a time
 
 [<tt>--libdir</tt> _directory_  (-I)]
     Add _directory_ to the list of directories searched for require.

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -325,6 +325,17 @@ module Rake
           "Execute some Ruby code, then continue with normal task processing.",
           lambda { |value| eval(value) }
         ],
+        ['--jobs',  '-j NUMBER',
+          "Specifies the maximum number of tasks to execute in parallel.",
+          lambda { |value|
+            value_i = value.to_i
+            if ( value_i.to_s == value && value_i > 0 )
+              options.max_concurrent_jobs = [value_i,1].max
+            else
+              puts "received '-j #{value}'. '#{value}' should be a positive integer"
+            end
+          }
+        ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -47,6 +47,7 @@ module Rake
       add_loader('rake', DefaultLoader.new)
       @tty_output = STDOUT.tty?
       @terminal_columns = ENV['RAKE_COLUMNS'].to_i
+      options.thread_pool_size = (2**(0.size * 8 - 2) - 1) # FIXNUM_MAX
     end
 
     # Run the Rake application.  The run method performs the following
@@ -330,7 +331,7 @@ module Rake
           lambda { |value|
             value_i = value.to_i
             if ( value_i.to_s == value && value_i > 0 )
-              options.max_concurrent_jobs = [value_i,1].max
+              options.thread_pool_size = value_i - 1
             else
               puts "received '-j #{value}'. '#{value}' should be a positive integer"
             end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -5,59 +5,47 @@ module Rake
 
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
-
+  #
   # MultiTasks load all their prerequisites onto a work queue (singleton
   # for the class) which is processed by a thread pool of variable size.
   # In order to prevent deadlocks, the current thread also processes
   # tasks on the queue until its prerequisite tasks are finished.
-
+  #
   class MultiTask < Task
-
     private
     def invoke_prerequisites(args, invocation_chain)
-      blocks = @prerequisites.collect { |r| lambda{ application[r, @scope].invoke_with_call_chain(args, invocation_chain) } }
-
-      if ( application.options.max_concurrent_jobs == nil )
-        threads = blocks.collect { |block| Thread.new {block.call} }
-        threads.each { |t| t.join }
-        return
-      end
-
       @@block_queue ||= Queue.new
-      @@thread_pool ||= ThreadGroup.new
 
-      block_count = blocks.count
+      block_count = @prerequisites.count
       block_threads = Set.new
       blocks_info_semaphore = Mutex.new
       
-      blocks.each do |block|
+      @prerequisites.each do |r|
         @@block_queue.enq lambda {
           blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
-          block.call
+          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
           blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
         }
-        
-        if @@thread_pool.list.count < (application.options.max_concurrent_jobs - 1)
-          @@thread_pool.add Thread.new { process_all_blocks }
-        end
       end
 
       process_all_blocks_until { block_count == 0 }
       blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
-      
     end
     
     def process_all_blocks_until
+      @@thread_pool ||= ThreadGroup.new
       begin
         while (!yield && something = @@block_queue.deq(true))
+          # track the thread pool size
+          if @@thread_pool.list.count < application.options.thread_pool_size
+            @@thread_pool.add Thread.new {
+              process_all_blocks_until { @@thread_pool.list.count > application.options.thread_pool_size}
+            }
+          end
           something.call
         end
       rescue ThreadError
       end
-    end
-    
-    def process_all_blocks
-      process_all_blocks_until {false}
     end
 
   end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -1,16 +1,64 @@
+require 'thread'
+require 'set'
+
 module Rake
 
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
-  #
+
+  # MultiTasks load all their prerequisites onto a work queue (singleton
+  # for the class) which is processed by a thread pool of variable size.
+  # In order to prevent deadlocks, the current thread also processes
+  # tasks on the queue until its prerequisite tasks are finished.
+
   class MultiTask < Task
+
     private
     def invoke_prerequisites(args, invocation_chain)
-      threads = @prerequisites.collect { |p|
-        Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
-      }
-      threads.each { |t| t.join }
-    end
-  end
+      blocks = @prerequisites.collect { |r| lambda{ application[r, @scope].invoke_with_call_chain(args, invocation_chain) } }
 
+      if ( application.options.max_concurrent_jobs == nil )
+        threads = blocks.collect { |block| Thread.new {block.call} }
+        threads.each { |t| t.join }
+        return
+      end
+
+      @@block_queue ||= Queue.new
+      @@thread_pool ||= ThreadGroup.new
+
+      block_count = blocks.count
+      block_threads = Set.new
+      blocks_info_semaphore = Mutex.new
+      
+      blocks.each do |block|
+        @@block_queue.enq lambda {
+          blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
+          block.call
+          blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
+        }
+        
+        if @@thread_pool.list.count < (application.options.max_concurrent_jobs - 1)
+          @@thread_pool.add Thread.new { process_all_blocks }
+        end
+      end
+
+      process_all_blocks_until { block_count == 0 }
+      blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
+      
+    end
+    
+    def process_all_blocks_until
+      begin
+        while (!yield && something = @@block_queue.deq(true))
+          something.call
+        end
+      rescue ThreadError
+      end
+    end
+    
+    def process_all_blocks
+      process_all_blocks_until {false}
+    end
+
+  end
 end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -6,47 +6,43 @@ module Rake
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
   #
-  # MultiTasks load all their prerequisites onto a work queue (singleton
-  # for the class) which is processed by a thread pool of variable size.
-  # In order to prevent deadlocks, the current thread also processes
-  # tasks on the queue until its prerequisite tasks are finished.
+  # invoke_prerequisites delegates processing of the prerequisites to
+  # threads in a thread pool until the thread pool is full.
+  # Then, execution of the prerequisites synchronously continues on,
+  # checking the size of the thread pool after each one just in case
+  # another thread has exited and it can delegate again.
+  #
+  # When all the prerequisites have been called, the current thread
+  # waits for the other threads processing the prerequisites
   #
   class MultiTask < Task
     private
-    def invoke_prerequisites(args, invocation_chain)
-      @@block_queue ||= Queue.new
+    def invoke_prerequisites(args, invocation_chain) # :nodoc:
+      @@thread_pool   ||= Set.new
+      our_threads = Set.new
+      mutex = Mutex.new
 
-      block_count = @prerequisites.count
-      block_threads = Set.new
-      blocks_info_semaphore = Mutex.new
-      
-      @prerequisites.each do |r|
-        @@block_queue.enq lambda {
-          blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
-          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
-          blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
+      @prerequisites.each do |p|
+        block = lambda {
+          application[p, @scope].invoke_with_call_chain(args, invocation_chain)
         }
-      end
-
-      process_all_blocks_until { block_count == 0 }
-      blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
-    end
-    
-    def process_all_blocks_until
-      @@thread_pool ||= ThreadGroup.new
-      begin
-        while (!yield && something = @@block_queue.deq(true))
-          # track the thread pool size
-          if @@thread_pool.list.count < application.options.thread_pool_size
-            @@thread_pool.add Thread.new {
-              process_all_blocks_until { @@thread_pool.list.count > application.options.thread_pool_size}
-            }
-          end
-          something.call
+        if ( @@thread_pool.size < application.options.thread_pool_size )
+          mutex.synchronize {
+            thread = Thread.new do
+              block.call
+              mutex.synchronize {
+                our_threads.delete(thread)
+                @@thread_pool.delete(thread)
+              }
+            end
+            our_threads.add(thread)
+            @@thread_pool.add(thread)
+          }
+        else
+          block.call
         end
-      rescue ThreadError
       end
+      mutex.synchronize { our_threads.dup }.each { |t| t.join }
     end
-
   end
 end


### PR DESCRIPTION
PROBLEM SUMMARY:

Rake can be unusable for builds invoking large numbers of concurrent external processes.

PROBLEM DESCRIPTION:

Rake makes it easy to maximize concurrency in builds with its "multitask" function. When using rake to build non-ruby projects quite often rake needs to execute shell tasks to process files. Unfortunately, when executing multitasks, rake spawns a new thread for each task-prerequisite. This shouldn't cause problems when the build code is pure ruby (for green threads), but when the tasks are executing external processes, the sheer number of spawned processes can cause the machine to thrash. Additionally ruby can reach the maximum number of open files (presumably because it's reading stdout for all those processes).

SOLUTION SUMMARY:

This request includes the code to add support for a "--jobs NUMBER (-j)" command-line option to specify the number of simultaneous tasks to execute.

SOLUTION:

The solution creates a work queue to which blocks calling the task-prerequisites are added and a thread pool to process them. To prevent deadlock, the task that added the pre-requisites processes items on the queue (alongside the thread pool) until its prerequisites have been processed.

To maintain backward compatibility, not passing -j reverts to the old behavior of unlimited concurrent tasks.

REQUIREMENTS:

The Ruby version requirements remain the same. "multi-task.rb" adds two new requirements: 'thread' and 'set'
