### PR TITLE
Add -j <max_jobs> and -m (all tasks multitasks) -- solution included

### DIFF
--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -31,11 +31,19 @@ Options are:
 [<tt>--execute-print</tt> _code_ (-p)]
     Execute some Ruby code, print the result, and exit.
 
-[<tt>--execute-continue</tt> _code_ (-p)]
+[<tt>--execute-continue</tt> _code_ (-E)]
     Execute some Ruby code, then continue with normal task processing.
 
 [<tt>--help</tt>  (-H)]
     Display some help text and exit.
+
+[<tt>--jobs</tt> _number_  (-j)]
+    Specifies the maximum number of concurrent tasks. The suggested
+    value is equal to the number of CPUs.
+    
+    Sample values:
+     default: unlimited concurrent tasks (standard rake behavior)
+     1: one task at a time
 
 [<tt>--libdir</tt> _directory_  (-I)]
     Add _directory_ to the list of directories searched for require.

--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -48,6 +48,9 @@ Options are:
 [<tt>--libdir</tt> _directory_  (-I)]
     Add _directory_ to the list of directories searched for require.
 
+[<tt>--multitask</tt> (-m)]
+    Treat all tasks as multitasks. ('make' semantics)
+
 [<tt>--nosearch</tt>  (-N)]
     Do not search for a Rakefile in parent directories.
 

--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -42,14 +42,15 @@ Options are:
     value is equal to the number of CPUs.
     
     Sample values:
-     default: unlimited concurrent tasks (standard rake behavior)
-     1: one task at a time
+     no -j   : unlimited concurrent tasks (standard rake behavior)
+     only -j : 2 concurrent tasks
+     -j 16   : 16 concurrent tasks
 
 [<tt>--libdir</tt> _directory_  (-I)]
     Add _directory_ to the list of directories searched for require.
 
 [<tt>--multitask</tt> (-m)]
-    Treat all tasks as multitasks. ('make' semantics)
+    Treat all tasks as multitasks. ('make/drake' semantics)
 
 [<tt>--nosearch</tt>  (-N)]
     Do not search for a Rakefile in parent directories.

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -325,6 +325,17 @@ module Rake
           "Execute some Ruby code, then continue with normal task processing.",
           lambda { |value| eval(value) }
         ],
+        ['--jobs',  '-j NUMBER',
+          "Specifies the maximum number of tasks to execute in parallel.",
+          lambda { |value|
+            value_i = value.to_i
+            if ( value_i.to_s == value && value_i > 0 )
+              options.max_concurrent_jobs = [value_i,1].max
+            else
+              puts "received '-j #{value}'. '#{value}' should be a positive integer"
+            end
+          }
+        ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -340,6 +340,9 @@ module Rake
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],
+        ['--multitask', '-m', "Treat all tasks as multitasks.",
+          lambda { |value| options.always_multitask = true; puts "All tasks are multitasks" }
+        ],
         ['--no-search', '--nosearch', '-N', "Do not search parent directories for the Rakefile.",
           lambda { |value| options.nosearch = true }
         ],

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -327,9 +327,7 @@ module Rake
         ],
         ['--jobs',  '-j [NUMBER]',
           "Specifies the maximum number of tasks to execute in parallel. (default:2)",
-          lambda { |value|
-            options.thread_pool_size = [(value || 2).to_i,2].max
-          }
+          lambda { |value| options.thread_pool_size = [(value || 2).to_i,2].max }
         ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -47,6 +47,7 @@ module Rake
       add_loader('rake', DefaultLoader.new)
       @tty_output = STDOUT.tty?
       @terminal_columns = ENV['RAKE_COLUMNS'].to_i
+      options.thread_pool_size = (2**(0.size * 8 - 2) - 1) # FIXNUM_MAX
     end
 
     # Run the Rake application.  The run method performs the following
@@ -330,7 +331,7 @@ module Rake
           lambda { |value|
             value_i = value.to_i
             if ( value_i.to_s == value && value_i > 0 )
-              options.max_concurrent_jobs = [value_i,1].max
+              options.thread_pool_size = value_i - 1
             else
               puts "received '-j #{value}'. '#{value}' should be a positive integer"
             end

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -325,22 +325,17 @@ module Rake
           "Execute some Ruby code, then continue with normal task processing.",
           lambda { |value| eval(value) }
         ],
-        ['--jobs',  '-j NUMBER',
-          "Specifies the maximum number of tasks to execute in parallel.",
+        ['--jobs',  '-j [NUMBER]',
+          "Specifies the maximum number of tasks to execute in parallel. (default:2)",
           lambda { |value|
-            value_i = value.to_i
-            if ( value_i.to_s == value && value_i > 0 )
-              options.thread_pool_size = value_i
-            else
-              puts "received '-j #{value}'. '#{value}' should be a positive integer"
-            end
+            options.thread_pool_size = [(value || 2).to_i,2].max
           }
         ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],
         ['--multitask', '-m', "Treat all tasks as multitasks.",
-          lambda { |value| options.always_multitask = true; puts "All tasks are multitasks" }
+          lambda { |value| options.always_multitask = true }
         ],
         ['--no-search', '--nosearch', '-N', "Do not search parent directories for the Rakefile.",
           lambda { |value| options.nosearch = true }

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -325,6 +325,17 @@ module Rake
           "Execute some Ruby code, then continue with normal task processing.",
           lambda { |value| eval(value) }
         ],
+        ['--jobs',  '-j NUMBER',
+          "Specifies the maximum number of tasks to execute in parallel.",
+          lambda { |value|
+            value_i = value.to_i
+            if ( value_i.to_s == value && value_i > 0 )
+              options.thread_pool_size = value_i
+            else
+              puts "received '-j #{value}'. '#{value}' should be a positive integer"
+            end
+          }
+        ],
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -6,43 +6,11 @@ module Rake
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
   #
-  # invoke_prerequisites delegates processing of the prerequisites to
-  # threads in a thread pool until the thread pool is full.
-  # Then, execution of the prerequisites synchronously continues on,
-  # checking the size of the thread pool after each one just in case
-  # another thread has exited and it can delegate again.
-  #
-  # When all the prerequisites have been called, the current thread
-  # waits for the other threads processing the prerequisites
-  #
   class MultiTask < Task
     private
-    def invoke_prerequisites(args, invocation_chain) # :nodoc:
-      @@thread_pool   ||= Set.new
-      our_threads = Set.new
-      mutex = Mutex.new
-
-      @prerequisites.each do |p|
-        block = lambda {
-          application[p, @scope].invoke_with_call_chain(args, invocation_chain)
-        }
-        if ( @@thread_pool.size < application.options.thread_pool_size )
-          mutex.synchronize {
-            thread = Thread.new do
-              block.call
-              mutex.synchronize {
-                our_threads.delete(thread)
-                @@thread_pool.delete(thread)
-              }
-            end
-            our_threads.add(thread)
-            @@thread_pool.add(thread)
-          }
-        else
-          block.call
-        end
-      end
-      mutex.synchronize { our_threads.dup }.each { |t| t.join }
+    def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
+      invoke_prerequisites_concurrently(task_args, invocation_chain)
     end
+
   end
 end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -5,59 +5,47 @@ module Rake
 
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
-
+  #
   # MultiTasks load all their prerequisites onto a work queue (singleton
   # for the class) which is processed by a thread pool of variable size.
   # In order to prevent deadlocks, the current thread also processes
   # tasks on the queue until its prerequisite tasks are finished.
-
+  #
   class MultiTask < Task
-
     private
     def invoke_prerequisites(args, invocation_chain)
-      blocks = @prerequisites.collect { |r| lambda{ application[r, @scope].invoke_with_call_chain(args, invocation_chain) } }
-
-      if ( application.options.max_concurrent_jobs == nil )
-        threads = blocks.collect { |block| Thread.new {block.call} }
-        threads.each { |t| t.join }
-        return
-      end
-
       @@block_queue ||= Queue.new
-      @@thread_pool ||= ThreadGroup.new
 
-      block_count = blocks.count
+      block_count = @prerequisites.count
       block_threads = Set.new
       blocks_info_semaphore = Mutex.new
       
-      blocks.each do |block|
+      @prerequisites.each do |r|
         @@block_queue.enq lambda {
           blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
-          block.call
+          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
           blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
         }
-        
-        if @@thread_pool.list.count < (application.options.max_concurrent_jobs - 1)
-          @@thread_pool.add Thread.new { process_all_blocks }
-        end
       end
 
       process_all_blocks_until { block_count == 0 }
       blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
-      
     end
     
     def process_all_blocks_until
+      @@thread_pool ||= ThreadGroup.new
       begin
         while (!yield && something = @@block_queue.deq(true))
+          # track the thread pool size
+          if @@thread_pool.list.count < application.options.thread_pool_size
+            @@thread_pool.add Thread.new {
+              process_all_blocks_until { @@thread_pool.list.count > application.options.thread_pool_size}
+            }
+          end
           something.call
         end
       rescue ThreadError
       end
-    end
-    
-    def process_all_blocks
-      process_all_blocks_until {false}
     end
 
   end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -1,16 +1,64 @@
+require 'thread'
+require 'set'
+
 module Rake
 
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
-  #
+
+  # MultiTasks load all their prerequisites onto a work queue (singleton
+  # for the class) which is processed by a thread pool of variable size.
+  # In order to prevent deadlocks, the current thread also processes
+  # tasks on the queue until its prerequisite tasks are finished.
+
   class MultiTask < Task
+
     private
     def invoke_prerequisites(args, invocation_chain)
-      threads = @prerequisites.collect { |p|
-        Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
-      }
-      threads.each { |t| t.join }
-    end
-  end
+      blocks = @prerequisites.collect { |r| lambda{ application[r, @scope].invoke_with_call_chain(args, invocation_chain) } }
 
+      if ( application.options.max_concurrent_jobs == nil )
+        threads = blocks.collect { |block| Thread.new {block.call} }
+        threads.each { |t| t.join }
+        return
+      end
+
+      @@block_queue ||= Queue.new
+      @@thread_pool ||= ThreadGroup.new
+
+      block_count = blocks.count
+      block_threads = Set.new
+      blocks_info_semaphore = Mutex.new
+      
+      blocks.each do |block|
+        @@block_queue.enq lambda {
+          blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
+          block.call
+          blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
+        }
+        
+        if @@thread_pool.list.count < (application.options.max_concurrent_jobs - 1)
+          @@thread_pool.add Thread.new { process_all_blocks }
+        end
+      end
+
+      process_all_blocks_until { block_count == 0 }
+      blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
+      
+    end
+    
+    def process_all_blocks_until
+      begin
+        while (!yield && something = @@block_queue.deq(true))
+          something.call
+        end
+      rescue ThreadError
+      end
+    end
+    
+    def process_all_blocks
+      process_all_blocks_until {false}
+    end
+
+  end
 end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -6,47 +6,43 @@ module Rake
   # Same as a regular task, but the immediate prerequisites are done in
   # parallel using Ruby threads.
   #
-  # MultiTasks load all their prerequisites onto a work queue (singleton
-  # for the class) which is processed by a thread pool of variable size.
-  # In order to prevent deadlocks, the current thread also processes
-  # tasks on the queue until its prerequisite tasks are finished.
+  # invoke_prerequisites delegates processing of the prerequisites to
+  # threads in a thread pool until the thread pool is full.
+  # Then, execution of the prerequisites synchronously continues on,
+  # checking the size of the thread pool after each one just in case
+  # another thread has exited and it can delegate again.
+  #
+  # When all the prerequisites have been called, the current thread
+  # waits for the other threads processing the prerequisites
   #
   class MultiTask < Task
     private
-    def invoke_prerequisites(args, invocation_chain)
-      @@block_queue ||= Queue.new
+    def invoke_prerequisites(args, invocation_chain) # :nodoc:
+      @@thread_pool   ||= Set.new
+      our_threads = Set.new
+      mutex = Mutex.new
 
-      block_count = @prerequisites.count
-      block_threads = Set.new
-      blocks_info_semaphore = Mutex.new
-      
-      @prerequisites.each do |r|
-        @@block_queue.enq lambda {
-          blocks_info_semaphore.synchronize { block_threads.add(Thread.current) }
-          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
-          blocks_info_semaphore.synchronize { block_threads.delete(Thread.current); block_count -= 1 }
+      @prerequisites.each do |p|
+        block = lambda {
+          application[p, @scope].invoke_with_call_chain(args, invocation_chain)
         }
-      end
-
-      process_all_blocks_until { block_count == 0 }
-      blocks_info_semaphore.synchronize { block_threads.dup }.each {|thread| thread.join}
-    end
-    
-    def process_all_blocks_until
-      @@thread_pool ||= ThreadGroup.new
-      begin
-        while (!yield && something = @@block_queue.deq(true))
-          # track the thread pool size
-          if @@thread_pool.list.count < application.options.thread_pool_size
-            @@thread_pool.add Thread.new {
-              process_all_blocks_until { @@thread_pool.list.count > application.options.thread_pool_size}
-            }
-          end
-          something.call
+        if ( @@thread_pool.size < application.options.thread_pool_size )
+          mutex.synchronize {
+            thread = Thread.new do
+              block.call
+              mutex.synchronize {
+                our_threads.delete(thread)
+                @@thread_pool.delete(thread)
+              }
+            end
+            our_threads.add(thread)
+            @@thread_pool.add(thread)
+          }
+        else
+          block.call
         end
-      rescue ThreadError
       end
+      mutex.synchronize { our_threads.dup }.each { |t| t.join }
     end
-
   end
 end

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -172,10 +172,14 @@ module Rake
 
     # Invoke all the prerequisites of a task.
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
-      prerequisite_tasks.each { |prereq|
-        prereq_args = task_args.new_scope(prereq.arg_names)
-        prereq.invoke_with_call_chain(prereq_args, invocation_chain)
-      }
+      if application.options.always_multitask
+        invoke_prerequisites_concurrently(task_args, invocation_chain)
+      else
+        prerequisite_tasks.each { |prereq|
+          prereq_args = task_args.new_scope(prereq.arg_names)
+          prereq.invoke_with_call_chain(prereq_args, invocation_chain)
+        }
+      end
     end
 
     def invoke_prerequisites_concurrently(args, invocation_chain)

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -171,10 +171,51 @@ module Rake
 
     # Invoke all the prerequisites of a task.
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
-      prerequisite_tasks.each { |prereq|
-        prereq_args = task_args.new_scope(prereq.arg_names)
-        prereq.invoke_with_call_chain(prereq_args, invocation_chain)
-      }
+      if ( application.options.always_multitask )
+          invoke_prerequisites_concurrently(task_args, invocation_chain)
+      else
+        prerequisite_tasks.each { |prereq|
+          prereq_args = task_args.new_scope(prereq.arg_names)
+          prereq.invoke_with_call_chain(prereq_args, invocation_chain)
+        }
+      end
+    end
+
+    # invoke_prerequisites_concurrently delegates processing of the
+    # prerequisites to threads in a thread pool until the thread pool
+    # is full. Then, execution of the prerequisites synchronously
+    # continues on, checking the size of the thread pool after each one
+    # just in case another thread has exited and it can delegate again.
+    #
+    # When all the prerequisites have been called, the current thread
+    # waits for the other threads processing the prerequisites
+    #
+    def invoke_prerequisites_concurrently(args, invocation_chain) # :nodoc:
+      @@thread_pool   ||= Set.new
+      our_threads = Set.new
+      mutex = Mutex.new
+
+      @prerequisites.each do |p|
+        block = lambda {
+          application[p, @scope].invoke_with_call_chain(args, invocation_chain)
+        }
+        if ( @@thread_pool.size < application.options.thread_pool_size )
+          mutex.synchronize {
+            thread = Thread.new do
+              block.call
+              mutex.synchronize {
+                our_threads.delete(thread)
+                @@thread_pool.delete(thread)
+              }
+            end
+            our_threads.add(thread)
+            @@thread_pool.add(thread)
+          }
+        else
+          block.call
+        end
+      end
+      mutex.synchronize { our_threads.dup }.each { |t| t.join }
     end
 
     # Format the trace flags for display.

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -1,4 +1,5 @@
 require 'rake/invocation_exception_mixin'
+require 'rake/worker_pool'
 
 module Rake
 
@@ -198,11 +199,12 @@ module Rake
       end
       application.enhance_with_matching_rule(name) if @actions.empty?
       @actions.each do |act|
+        @@worker_pool ||= WorkerPool.new(application.options.thread_pool_size)
         case act.arity
         when 1
-          act.call(self)
+           @@worker_pool.execute_block {act.call(self)}
         else
-          act.call(self, args)
+           @@worker_pool.execute_block {act.call(self, args)}
         end
       end
     end

--- a/lib/rake/worker_pool.rb
+++ b/lib/rake/worker_pool.rb
@@ -1,0 +1,109 @@
+require 'thread'
+require 'set'
+
+module Rake
+  class WorkerPool
+    attr_accessor :maximum_size   # this is the maximum size of the pool
+
+    def initialize(max = nil)
+      @threads = Set.new          # this holds the set of threads in the pool
+      @threads_mutex = Mutex.new  # use this whenever r/w @threads
+      @queue = Queue.new          # this holds blocks to be executed
+      @wait_cv = ConditionVariable.new # alerts threads sleeping from calling #wait
+      if (max && max > 0)
+        self.maximum_size= max
+      else
+        self.maximum_size= (2**(0.size * 8 - 2) - 1) # FIXNUM_MAX
+      end
+    end
+
+    def execute_block(&block)
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+      exception = nil
+      
+      mutex.synchronize {
+        @queue.enq lambda {
+          begin
+            block.call
+          rescue Exception => e
+            exception = e
+          ensure
+            # we *have* to have this 'ensure' because we *have* to
+            # call cv.signal to wake up WorkerPool#execute_block
+            # which is asleep because it called cv.wait(mutex)
+            mutex.synchronize{ cv.signal }
+          end
+        }
+        add_thread
+        cv.wait(mutex)
+      }
+      if exception
+        # IMPORTANT: In order to trace execution through threads,
+        # we concatenate the backtrace of the exception (thrown in a
+        # different context), with the backtrace of the
+        # current context. In this way, you can see the backtrace
+        # all the way through from when you called #execute_block
+        # to where it was raised in the thread that was executing
+        # that block.
+        #
+        # backtrace looks like this:
+        #   exception.backtrace (in original thread context)
+        #            |
+        #            |
+        #   caller (in our context)
+        #
+        exception.set_backtrace exception.backtrace.concat(caller)
+        raise exception
+      end
+    end
+    
+    def add_thread
+      @threads_mutex.synchronize {
+        if @threads.size >= self.maximum_size
+          next
+        end
+        t = Thread.new do
+          begin
+            while @threads.size <= self.maximum_size
+              @queue.deq.call
+            end
+          ensure
+            # we *have* to have this 'ensure' because we *have* to
+            # call @wait_cv.signal. This wakes up the Thread
+            # that is sleeping because it called WorkerPool#wait
+            @threads_mutex.synchronize{
+              @threads.delete(Thread.current)
+              @wait_cv.signal
+            }
+          end
+        end
+        @threads.add t
+      }
+    end
+    private :add_thread
+    
+    def wait
+      # we synchronize on @threads_mutex because we don't want
+      # any threads added while we wait, only removed
+      # we set the maximum size to 0 and then add enough blocks to the
+      # queue so any sleeping threads will wake up and notice there are
+      # more threads than the limit and exit
+      @threads_mutex.synchronize {
+        saved_maximum_size, @maximum_size = @maximum_size, 0
+        @threads.each { @queue.enq lambda { ; } } # wake them all up
+        # here, we sleep and wait for a signal off @wait_cv
+        # we will get it once for each sleeping thread so we watch the
+        # thread count
+        while (@threads.size > 0)
+          @wait_cv.wait(@threads_mutex)
+        end
+        
+        # now everything has been executed and we are ready to
+        # start accepting more work so we raise the limit back
+        @maximum_size = saved_maximum_size
+      }
+    end
+
+  end
+end

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -33,6 +33,7 @@ class TestRakeApplicationOptions < Rake::TestCase
     assert_nil opts.dryrun
     assert_nil opts.ignore_system
     assert_nil opts.load_system
+    assert_nil opts.always_multitask
     assert_nil opts.nosearch
     assert_equal ['rakelib'], opts.rakelib
     assert_nil opts.show_prereqs
@@ -40,6 +41,7 @@ class TestRakeApplicationOptions < Rake::TestCase
     assert_nil opts.show_tasks
     assert_nil opts.silent
     assert_nil opts.trace
+    assert_nil opts.thread_pool_size
     assert_equal ['rakelib'], opts.rakelib
     assert ! Rake::FileUtilsExt.verbose_flag
     assert ! Rake::FileUtilsExt.nowrite_flag
@@ -110,12 +112,30 @@ class TestRakeApplicationOptions < Rake::TestCase
     assert_equal :exit, @exit
   end
 
+  def test_jobs
+    flags(['--jobs', '4'], ['-j', '4']) do |opts|
+      assert_equal 4, opts.thread_pool_size
+    end
+    flags(['--jobs', 'asdas'], ['-j', 'asdas']) do |opts|
+      assert_equal 2, opts.thread_pool_size
+    end
+    flags('--jobs', '-j') do |opts|
+      assert_equal 2, opts.thread_pool_size
+    end
+  end
+
   def test_libdir
     flags(['--libdir', 'xx'], ['-I', 'xx'], ['-Ixx']) do |opts|
       $:.include?('xx')
     end
   ensure
     $:.delete('xx')
+  end
+
+  def test_multitask
+    flags('--multitask', '-m') do |opts|
+      assert_equal opts.always_multitask, true
+    end
   end
 
   def test_rakefile

--- a/test/test_rake_test_worker_pool.rb
+++ b/test/test_rake_test_worker_pool.rb
@@ -1,0 +1,90 @@
+require File.expand_path('../helper', __FILE__)
+require 'rake/worker_pool'
+require 'test/unit/assertions'
+
+class TestRakeTestWorkerPool < Rake::TestCase
+  include Rake
+  
+  def test_block_order
+    mx = Mutex.new
+    block = lambda {|executor,count=20,result=""|
+      return if (count < 1)
+      mx.synchronize{ result << count.to_s }
+      sleep(rand * 0.01)
+      executor.call( [lambda {block.call(executor,count-1,result)}] )
+      result
+    }
+
+    old = lambda {|b|
+        threads = b.collect {|c| Thread.new(c) {|d| d.call } }
+        threads.each {|t| t.join }
+    }
+
+    wp = WorkerPool.new(4)
+    new = lambda {|b| wp.execute_blocks b }
+    
+    assert_equal(block.call(old), block.call(new))
+  end
+
+  # test that there are no deadlocks within the worker pool itself
+  def test_deadlocks
+    wp = WorkerPool.new(10)
+    blocks = []
+    10.times {
+       inner_block = lambda {|count=5|
+        return if (count < 1)
+        sleep(rand * 0.000001)
+        inner_blocks = []
+        3.times {  inner_blocks << lambda {inner_block.call(count-1)} }
+        wp.execute_blocks inner_blocks
+      }
+      blocks << inner_block
+    }
+    wp.execute_blocks blocks
+  end
+
+  # test that throwing an exception way down in the blocks propagates
+  # to the top
+  def test_exceptions
+    wp = WorkerPool.new(4)
+    deep_exception_block = lambda {|count=3|
+      raise Exception.new if ( count < 1 )
+      deep_exception_block.call(count-1)
+    }
+    assert_raises(Exception) do
+      wp.execute_blocks [deep_exception_block]
+    end
+  end
+
+  def test_thread_count
+    mutex = Mutex.new
+    expected_thread_count = 2
+    wp = WorkerPool.new(expected_thread_count)
+
+    # the lambda code will determine how many threads are running in
+    # the pool
+    blocks = []
+    thread_count = 0
+    should_sleep = true
+    (expected_thread_count*2).times do
+      blocks << lambda {
+        mutex.synchronize do; stack_prefix = "#{__FILE__}:#{__LINE__}" # this synchronize will be on the stack
+          sleep 1 if should_sleep # this lets all the threads wait on the mutex
+          threads = Thread.list
+          backtraces = threads.collect {|t| t.backtrace}
+          # sometimes a thread doesn't return a thread count
+          if ( threads.count == backtraces.count )
+            should_sleep = false
+            # finds all the backtraces that contain our mutex.synchronize call
+            our_bt = backtraces.find_all{|bt| bt && bt.index{|tr| tr.start_with? stack_prefix}!=nil }
+            thread_count = [thread_count, our_bt.count].max
+          end
+        end
+      }
+    end
+    
+    wp.execute_blocks blocks
+    assert_equal(expected_thread_count, thread_count)
+  end
+end
+


### PR DESCRIPTION
## PROBLEM SUMMARY (THE CASE FOR -j and -m)

Rake can be unusable for builds invoking large numbers of concurrent external processes.
## PROBLEM DESCRIPTION

Rake makes it easy to maximize concurrency in builds with its "multitask" function. When using rake to build non-ruby projects quite often rake needs to execute shell tasks to process files. Unfortunately, when executing multitasks, rake spawns a new thread for each task-prerequisite. This shouldn't cause problems when the build code is pure ruby (for green threads), but when the tasks are executing external processes, the sheer number of spawned processes can cause the machine to thrash. Additionally ruby can reach the maximum number of open files (presumably because it's reading stdout for all those processes).
## SOLUTION SUMMARY

This request includes the code to add support for a `--jobs NUMBER (-j)` command-line option to specify the number of simultaneous tasks to execute.
- To maintain backward compatibility, not passing `-j` reverts to the old behavior of unlimited concurrent tasks.

As a nod to [drake](http://drake.rubyforge.org), a `--multitask (-m)` flag is also included which when supplied, changes tasks into multitasks.
## SOLUTION

Rather than spawning a new thread per prerequisite `MultiTask` now sends its prerequisites to a `WorkerPool` object. `WorkerPool.new(n).execute_blocks` has the same semantics as `Thread.new`...`join` but caps the thread count at `n`.
### Core Change

```
threads = @prerequisites.collect { |p|
  Thread.new(p) { |r| application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
}
threads.each { |t| t.join }
```

...becomes...

```
@@wp ||= WorkerPool.new(application.options.thread_pool_size)

blocks = @prerequisites.collect { |r|
  lambda { application[r, @scope].invoke_with_call_chain(args, invocation_chain) }
}
@@wp.execute_blocks blocks
```

To support `-m`, the `MultiTask` implementation has moved to `Task#invoke_prerequisites_concurrently` and is called from `MultiTask#invoke_prerequisites`. This enables concurrent behavior for `Task`  when `-m` is used.
### Details

`WorkerPool#execute_blocks` adds the passed-in blocks to a queue, ensures there are enough threads to execute them (under the maximum), and sleeps the current thread until the blocks are processed.

This creates a few potential problems:

> What if all of the blocks then called `#execute_blocks`? Wouldn't that sleep all the threads?

Yes it would. This is solved as `#execute_blocks` removes the current thread from the thread pool just before it sleeps and creates a new one in its place. When all the blocks are processed, the current thread is added back to the pool (adjusting for the max-size). There are always enough available threads in the thread pool for processing.

> When do the threads shutdown?

`WorkerPool#execute_blocks` knows how many threads are waiting for their blocks to be processed. If, upon its awakening, it notices there are no threads waiting on blocks, it shuts down the thread pool.
### Statistics

```
 ---LINES--         ----LOC---
  old   new  diff    old   new  diff  File Name
 ----------  ----   ----------  ----  ----------
  598   605    +7    477   484    +7  lib/rake/application.rb
   16    13    -3     11     8    -3  lib/rake/multi_task.rb
  327   341   +14    210   222   +12  lib/rake/task.rb
        111                 80        lib/rake/worker_pool.rb
 4264  4393         2696  2792        TOTAL
 ------------------------------------------------
             +129                +96  SUMMARY
```
## TESTS

Tests are included for all new functionality
## REQUIREMENTS

The Ruby version requirements remain the same. `lib/rake/worker_pool.rb` adds two new requirements: `thread` and `set`
