### PR TITLE
stop using private constants

### DIFF
--- a/lib/rake/file_utils_ext.rb
+++ b/lib/rake/file_utils_ext.rb
@@ -21,12 +21,13 @@ module Rake
     $fileutils_verbose = true
     $fileutils_nowrite = false
 
-    FileUtils::OPT_TABLE.each do |name, opts|
+    FileUtils.commands.each do |name|
+      opts = FileUtils.options_of name
       default_options = []
-      if opts.include?(:verbose) || opts.include?("verbose")
+      if opts.include?("verbose")
         default_options << ':verbose => FileUtilsExt.verbose_flag'
       end
-      if opts.include?(:noop) || opts.include?("noop")
+      if opts.include?("noop")
         default_options << ':noop => FileUtilsExt.nowrite_flag'
       end
 


### PR DESCRIPTION
`FileUtils::OPT_TABLE` [is declared as :nodoc: and commented as "internal
use only"](https://github.com/ruby/ruby/blob/trunk/lib/fileutils.rb#L128), so use the FileUtils accessors rather than directly referring
to the constant.
