### PR TITLE
Propagate signals exceptions that terminate a TestTask subprocess.

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -96,7 +96,11 @@ module Rake
       desc "Run tests" + (@name==:test ? "" : " for #{@name}")
       task @name do
         FileUtilsExt.verbose(@verbose) do
-          ruby "#{ruby_opts_string} #{run_code} #{file_list_string} #{option_list}"
+          ruby "#{ruby_opts_string} #{run_code} #{file_list_string} #{option_list}" do |ok, status|
+            if !ok && status.respond_to?(:signaled?) && status.signaled?
+              raise SignalException.new(status.termsig)
+            end
+          end
         end
       end
       self


### PR DESCRIPTION
Problem:

Running `rake test` for a rails app, then trying to cancel the tests with Ctrl-C will only cancel a single test suite.

Analysis:

Rails uses `Rake::Task[task].invoke` to run multiple `Rake::TestTask` tasks (unit, function and integration tasks), collects `StandardError`s raised from any of these `invoke` calls, then uses that to print a summary of which suites had errors.  However, these are also catching test tasks terminated by a signal.

`Rake::TestTask` uses the `system` function to run a test suite in a subprocesses.  The subprocesses exits with an non-zero status when there are errors, and `Rake::TestTask` will raise a RuntimeError even if the subprocesses is terminated with a signal.  So, the SignalException gets translated into a StandardError causing it be caught.

Solution:

Detect if the `Rake::TestTask` subprocess was terminated by a signal, and raise a SignalException in this case.
