### PR TITLE
Make glob order alphabetical, not file-system dependent

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -73,7 +73,7 @@ File.chmod(0755, rake_dest)
 
 # The library files
 
-files = Dir.chdir('lib') { Dir['**/*.rb'] }
+files = Dir.chdir('lib') { Dir['**/*.rb'].sort }
 
 for fn in files
   fn_dir = File.dirname(fn)

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -178,7 +178,7 @@ module Rake
     def have_rakefile
       @rakefiles.each do |fn|
         if File.exist?(fn)
-          others = Dir.glob(fn, File::FNM_CASEFOLD)
+          others = Dir.glob(fn, File::FNM_CASEFOLD).sort
           return others.size == 1 ? others.first : fn
         elsif fn == ''
           return fn
@@ -512,7 +512,7 @@ module Rake
     end
 
     def glob(path, &block)
-      Dir[path.gsub("\\", '/')].each(&block)
+      Dir[path.gsub("\\", '/')].sort.each(&block)
     end
     private :glob
 

--- a/lib/rake/contrib/ftptools.rb
+++ b/lib/rake/contrib/ftptools.rb
@@ -127,7 +127,7 @@ module Rake # :nodoc:
     # Upload all files matching +wildcard+ to the uploader's root
     # path.
     def upload_files(wildcard)
-      Dir[wildcard].each do |fn|
+      Dir[wildcard].sort.each do |fn|
         upload(fn)
       end
     end

--- a/lib/rake/contrib/sys.rb
+++ b/lib/rake/contrib/sys.rb
@@ -27,7 +27,7 @@ module Sys
   # Install all the files matching +wildcard+ into the +dest_dir+
   # directory.  The permission mode is set to +mode+.
   def install(wildcard, dest_dir, mode)
-    Dir[wildcard].each do |fn|
+    Dir[wildcard].sort.each do |fn|
       File.install(fn, dest_dir, mode, $verbose)
     end
   end
@@ -81,7 +81,7 @@ module Sys
   # recursively delete directories.
   def delete(*wildcards)
     wildcards.each do |wildcard|
-      Dir[wildcard].each do |fn|
+      Dir[wildcard].sort.each do |fn|
         if File.directory?(fn)
           log "Deleting directory #{fn}"
           Dir.delete(fn)
@@ -96,10 +96,10 @@ module Sys
   # Recursively delete all files and directories matching +wildcard+.
   def delete_all(*wildcards)
     wildcards.each do |wildcard|
-      Dir[wildcard].each do |fn|
+      Dir[wildcard].sort.each do |fn|
         next if ! File.exist?(fn)
         if File.directory?(fn)
-          Dir["#{fn}/*"].each do |subfn|
+          Dir["#{fn}/*"].sort.each do |subfn|
             next if subfn=='.' || subfn=='..'
             delete_all(subfn)
           end
@@ -161,7 +161,7 @@ module Sys
   # Perform a block with each file matching a set of wildcards.
   def for_files(*wildcards)
     wildcards.each do |wildcard|
-      Dir[wildcard].each do |fn|
+      Dir[wildcard].sort.each do |fn|
         yield(fn)
       end
     end
@@ -172,7 +172,7 @@ module Sys
   private # ----------------------------------------------------------
 
   def for_matching_files(wildcard, dest_dir)
-    Dir[wildcard].each do |fn|
+    Dir[wildcard].sort.each do |fn|
       dest_file = File.join(dest_dir, fn)
       parent = File.dirname(dest_file)
       makedirs(parent) if ! File.directory?(parent)

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -340,7 +340,7 @@ module Rake
 
     # Add matching glob patterns.
     def add_matching(pattern)
-      Dir[pattern].each do |fn|
+      Dir[pattern].sort.each do |fn|
         self << fn unless exclude?(fn)
       end
     end

--- a/lib/rake/runtest.rb
+++ b/lib/rake/runtest.rb
@@ -5,7 +5,7 @@ module Rake
   include Test::Unit::Assertions
 
   def run_tests(pattern='test/test*.rb', log_enabled=false)
-    Dir["#{pattern}"].each { |fn|
+    Dir["#{pattern}"].sort.each { |fn|
       $stderr.puts fn if log_enabled
       begin
         require fn


### PR DESCRIPTION
Dir[] has undefined order, so sorting it is strictly better than not.
Sorting should not have a performance impact in any realistic use case:
Sorting 100k shuffled elements is near-instantaneous, and sorting 1M
elements takes ~3 seconds, so file system access time will always
dominate.

One particular reason why this is useful is that undefined ordering is a
major source of flickering test suite failures.
