### PR TITLE
The DSL for multitask doesn't support passing args to the multitask (patch+test included)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /coverage
 /html
 /pkg
+
+.DS_Store

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -78,8 +78,8 @@ module Rake
     # Example:
     #   multitask :deploy => [:deploy_gem, :deploy_rdoc]
     #
-    def multitask(args, &block)
-      Rake::MultiTask.define_task(args, &block)
+    def multitask(*args, &block)
+      Rake::MultiTask.define_task(*args, &block)
     end
 
     # Create a new rake namespace and use it for evaluating the given

--- a/test/test_rake_multi_task.rb
+++ b/test/test_rake_multi_task.rb
@@ -47,5 +47,13 @@ class TestRakeMultiTask < Rake::TestCase
     assert @runs.index("B0") < @runs.index("B1")
     assert @runs.index("B1") < @runs.index("B2")
   end
+
+  def test_multitasks_with_parameters
+    task :a, [:arg] do |t,args| add_run(args[:arg]) end
+    multitask :b, [:arg] => [:a] do |t,args| add_run(args[:arg]+'mt') end
+    Task[:b].invoke "b"
+    assert @runs[0] == "b"
+    assert @runs[1] == "bmt"
+  end
 end
 


### PR DESCRIPTION
Before this patch, the following code:

```
multitask :a, [:b] => :c
```

yields this error:

> ArgumentError: wrong number of arguments (2 for 1)
