### PR TITLE
Nested namespaces with array

### DIFF
--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -93,11 +93,25 @@ module Rake
     #   end
     #   task_run = ns[:run] # find :run in the given namespace.
     #
+    #   or
+    #
+    #   ns = namespace ["deeply", "nested"] do
+    #     task :run
+    #   end
+    #   task_run = ns[:run] # find :run in the given namespace.
     def namespace(name=nil, &block)
-      name = name.to_s if name.kind_of?(Symbol)
-      name = name.to_str if name.respond_to?(:to_str)
-      unless name.kind_of?(String) || name.nil?
-        raise ArgumentError, "Expected a String or Symbol for a namespace name"
+      process_name = lambda do |name|
+        name = name.to_s if name.kind_of?(Symbol)
+        name = name.to_str if name.respond_to?(:to_str)
+        unless name.kind_of?(String) || name.nil?
+          raise ArgumentError, "Expected a String or Symbol for a namespace name"
+        end
+        name
+      end
+      if name.kind_of?(Array)
+        name = name.map{|n| process_name.call(n)}.join(":")
+      else
+        name = process_name.call(name)
       end
       Rake.application.in_namespace(name, &block)
     end

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -7,6 +7,13 @@ class TestRakeDsl < Rake::TestCase
     Rake::Task.clear
   end
 
+  def test_namespace_command_nested_with_array
+    namespace ["a", "b", "c"] do
+      task "123"
+    end
+    refute_nil Rake::Task["a:b:c:123"]
+  end
+
   def test_namespace_command
     namespace "n" do
       task "t"


### PR DESCRIPTION
I sometimes find it annoying that I need to define deeply nested namespaces like:

``` ruby
namespace :one do
  namespace :two do
    task :winner
  end
end
```

Instead it would be nice to do

``` ruby
namespace [:one, :two] do
  task :winner
end
```

What do you think?
