### PR TITLE
Add -m option to change all tasks into multitasks

### DIFF
--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -49,6 +49,9 @@ Options are:
 [<tt>--libdir</tt> _directory_  (-I)]
     Add _directory_ to the list of directories searched for require.
 
+[<tt>--multitask</tt> (-m)]
+    Treat all tasks as multitasks. ('make/drake' semantics)
+
 [<tt>--nosearch</tt>  (-N)]
     Do not search for a Rakefile in parent directories.
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -338,6 +338,9 @@ module Rake
         ['--libdir', '-I LIBDIR', "Include LIBDIR in the search path for required modules.",
           lambda { |value| $:.push(value) }
         ],
+        ['--multitask', '-m', "Treat all tasks as multitasks.",
+          lambda { |value| options.always_multitask = true }
+        ],
         ['--no-search', '--nosearch', '-N', "Do not search parent directories for the Rakefile.",
           lambda { |value| options.nosearch = true }
         ],

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -5,13 +5,8 @@ module Rake
   #
   class MultiTask < Task
     private
-    def invoke_prerequisites(args, invocation_chain)
-      futures = @prerequisites.collect do |p|
-        application.thread_pool.future(p) do |r|
-          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
-        end
-      end
-      futures.each { |f| f.call }
+    def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
+      invoke_prerequisites_concurrently(task_args, invocation_chain)
     end
   end
 

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -171,10 +171,24 @@ module Rake
 
     # Invoke all the prerequisites of a task.
     def invoke_prerequisites(task_args, invocation_chain) # :nodoc:
-      prerequisite_tasks.each { |prereq|
-        prereq_args = task_args.new_scope(prereq.arg_names)
-        prereq.invoke_with_call_chain(prereq_args, invocation_chain)
-      }
+      if application.options.always_multitask
+        invoke_prerequisites_concurrently(task_args, invocation_chain)
+      else
+        prerequisite_tasks.each { |prereq|
+          prereq_args = task_args.new_scope(prereq.arg_names)
+          prereq.invoke_with_call_chain(prereq_args, invocation_chain)
+        }
+      end
+    end
+
+    # Invoke all the prerequisites of a task in parallel.
+    def invoke_prerequisites_concurrently(args, invocation_chain) # :nodoc:
+      futures = @prerequisites.collect do |p|
+        application.thread_pool.future(p) do |r|
+          application[r, @scope].invoke_with_call_chain(args, invocation_chain)
+        end
+      end
+      futures.each { |f| f.call }
     end
 
     # Format the trace flags for display.

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -33,6 +33,7 @@ class TestRakeApplicationOptions < Rake::TestCase
     assert_nil opts.dryrun
     assert_nil opts.ignore_system
     assert_nil opts.load_system
+    assert_nil opts.always_multitask
     assert_nil opts.nosearch
     assert_equal ['rakelib'], opts.rakelib
     assert_nil opts.show_prereqs
@@ -129,6 +130,12 @@ class TestRakeApplicationOptions < Rake::TestCase
     end
   ensure
     $:.delete('xx')
+  end
+
+  def test_multitask
+    flags('--multitask', '-m') do |opts|
+      assert_equal opts.always_multitask, true
+    end
   end
 
   def test_rakefile


### PR DESCRIPTION
This pull request includes code which:

Adds a new method `Rake::Task#invoke_prerequisites_concurrently`.

`Rake::MultiTask#invoke_prerequisites` always calls
`Rake::Task#invoke_prerequisites_concurrently` and now
`Rake::Task#invoke_prerequisites` will call it when
`Rake.application.options.always_multitask == true`.

Passing `-m` at the command-line sets
`Rake.application.options.always_multitask` to `true`

New tests are added as well as documentation.
