### PR TITLE
Cleaned up the ThreadPool interface

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -109,7 +109,7 @@ module Rake
     end
 
     def thread_pool
-      @thread_pool ||= ThreadPool.new options.thread_pool_size
+      @thread_pool ||= ThreadPool.new(options.thread_pool_size||FIXNUM_MAX)
     end
 
     # private ----------------------------------------------------------------
@@ -604,5 +604,9 @@ module Rake
 
       backtrace.find { |str| str =~ re } || ''
     end
+
+  private
+    FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
+    
   end
 end

--- a/lib/rake/multi_task.rb
+++ b/lib/rake/multi_task.rb
@@ -11,7 +11,7 @@ module Rake
           application[r, @scope].invoke_with_call_chain(args, invocation_chain)
         end
       end
-      futures.each { |f| f.call }
+      futures.each { |f| f.value }
     end
   end
 

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -15,11 +15,11 @@ module Rake
       @join_cond = @threads_mon.new_cond
     end
     
-    # Creates a future to be executed in the ThreadPool.
-    # The args are passed to the block when executing (similarly to Thread#new)
-    # The return value is a Proc which may or may not be already executing in
-    # another thread. Calling Proc#call will sleep the current thread until
-    # the future is finished and will return the result (or raise an Exception
+    # Creates a future to be executed in the +ThreadPool+.
+    # The args are passed to the block when executing (similarly to <tt>Thread#new</tt>)
+    # The return value is a +Proc+ which may or may not be already executing in
+    # another thread. Calling <tt>Proc#call</tt> will sleep the current thread until
+    # the future is finished and will return the result (or raise an exception
     # thrown from the future)
     def future(*args,&block)
       # capture the local args for the block (like Thread#start)
@@ -92,7 +92,7 @@ module Rake
     end
 
   private
-    def start_thread
+    def start_thread # :nodoc:
       @threads_mon.synchronize do
         next unless @threads.count < @max_thread_count
 
@@ -118,11 +118,11 @@ module Rake
     
     # for testing only
     
-    def __queue__
+    def __queue__ # :nodoc:
       @queue
     end
     
-    def __threads__
+    def __threads__ # :nodoc:
       @threads.dup
     end
     

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -6,21 +6,21 @@ module Rake
   class ThreadPool
 
     # Creates a ThreadPool object.
-    # The parameter is the size of the pool. By default, the pool uses unlimited threads.
-    def initialize(thread_count=nil)
-      @max_thread_count = [(thread_count||FIXNUM_MAX), 0].max
+    # The parameter is the size of the pool.
+    def initialize(thread_count)
+      @max_thread_count = [thread_count, 0].max
       @threads = Set.new
       @threads_mon = Monitor.new
       @queue = Queue.new
       @join_cond = @threads_mon.new_cond
     end
     
-    # Creates a future to be executed in the +ThreadPool+.
+    # Creates a future executed by the +ThreadPool+.
     # The args are passed to the block when executing (similarly to <tt>Thread#new</tt>)
-    # The return value is a +Proc+ which may or may not be already executing in
-    # another thread. Calling <tt>Proc#call</tt> will sleep the current thread until
-    # the future is finished and will return the result (or raise an exception
-    # thrown from the future)
+    # The return value is an object representing a future which has been created and
+    # added to the queue in the pool. Sending <tt>#value</tt> to the object will sleep
+    # the current thread until the future is finished and will return the result (or
+    # raise an exception thrown from the future)
     def future(*args,&block)
       # capture the local args for the block (like Thread#start)
       local_args = args.collect { |a| begin; a.dup; rescue; a; end }
@@ -65,6 +65,10 @@ module Rake
           end
         end
         promise_error.equal?(NOT_SET) ? promise_result : raise(promise_error)
+      end
+
+      def promise.value
+        call
       end
 
       @queue.enq promise
@@ -127,7 +131,6 @@ module Rake
     end
     
     NOT_SET = Object.new.freeze # :nodoc:
-    FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
   end
   
 end

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -126,8 +126,8 @@ module Rake
       @threads.dup
     end
     
-    NOT_SET = Object.new.freeze
-    FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # FIXNUM_MAX
+    NOT_SET = Object.new.freeze # :nodoc:
+    FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
   end
   
 end


### PR DESCRIPTION
Since the `ThreadPool` as currently checked into Rake 0.9.3.beta.2 is a public api, this change ensures that api is minimal, documented, and exposes the fewest dependencies necessary to function, allowing for future and gradual, expansion.

Most notably, the interface is completely documented and certain private things are hidden from documentation.

The futures returned by `ThreadPool#future` are of an undocumented type, but are guaranteed to have a `#value` method which will return the value of the future.
