### PR TITLE
ThreadPool no longer creates new threads to compensate for threads sleeping on futures

### DIFF
--- a/lib/rake/private_reader.rb
+++ b/lib/rake/private_reader.rb
@@ -1,0 +1,20 @@
+module Rake
+
+  # Include PrivateReader to use +private_reader+.
+  module PrivateReader           # :nodoc: all
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+
+      # Declare a list of private accessors
+      def private_reader(*names)
+        attr_reader(*names)
+        private(*names)
+      end
+    end
+
+  end
+end

--- a/lib/rake/promise.rb
+++ b/lib/rake/promise.rb
@@ -33,7 +33,6 @@ module Rake
           chore
           stat :releasing_lock_on, :item_id => object_id
         end
-        stat :awake_from, :item_id => object_id
       end
       error? ? raise(@error) : @result
     end

--- a/lib/rake/promise.rb
+++ b/lib/rake/promise.rb
@@ -1,0 +1,88 @@
+module Rake
+
+  # A Promise object represents a promise to do work (a chore) in the
+  # future. The promise is created with a block and a list of
+  # arguments for the block. Calling value will return the value of
+  # the promised chore.
+  #
+  # Used by ThreadPool.
+  #
+  class Promise               # :nodoc: all
+    NOT_SET = Object.new.freeze # :nodoc:
+
+    attr_accessor :recorder
+
+    # Create a promise to do the chore specified by the block.
+    def initialize(args, &block)
+      @mutex = Mutex.new
+      @result = NOT_SET
+      @error = NOT_SET
+      @args = args.collect { |a| begin; a.dup; rescue; a; end }
+      @block = block
+    end
+
+    # Return the value of this promise.
+    #
+    # If the promised chore is not yet complete, then do the work
+    # synchronously. We will wait.
+    def value
+      unless complete?
+        stat :will_wait_on_promise, :item_id => object_id
+        @mutex.synchronize { chore }
+        stat :did_wait_on_promise, :item_id => object_id
+      end
+      error? ? raise(@error) : @result
+    end
+
+    # If no one else is working this promise, go ahead and do the chore.
+    def work
+      if @mutex.try_lock
+        chore
+        @mutex.unlock
+      end
+    end
+
+    private
+
+    # Perform the chore promised
+    def chore
+      return if complete?
+      stat :promise_will_execute, :item_id => object_id
+      begin
+        @result = @block.call(*@args)
+      rescue Exception => e
+        @error = e
+      end
+      stat :promise_did_execute, :item_id => object_id
+      discard
+    end
+
+    # Do we have a result for the promise
+    def result?
+      ! @result.equal?(NOT_SET)
+    end
+
+    # Did the promise throw an error
+    def error?
+      ! @error.equal?(NOT_SET)
+    end
+
+    # Are we done with the promise
+    def complete?
+      result? || error?
+    end
+
+    # free up these items for the GC
+    def discard
+      @args = nil
+      @block = nil
+    end
+
+    # Record execution statistics if there is a recorder
+    def stat(*args)
+      @recorder.call(*args) if @recorder
+    end
+
+  end
+
+end

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -196,7 +196,7 @@ module Rake
           application[r, @scope].invoke_with_call_chain(args, invocation_chain)
         end
       end
-      futures.each { |f| f.call }
+      futures.each { |f| f.value }
     end
 
     # Format the trace flags for display.

--- a/lib/rake/thread_history_display.rb
+++ b/lib/rake/thread_history_display.rb
@@ -16,7 +16,7 @@ module Rake
     def show
       puts "Job History:"
       stats.each do |stat|
-        stat[:data] ||= []
+        stat[:data] ||= {}
         rename(stat, :thread, threads)
         rename(stat[:data], :item_id, items)
         rename(stat[:data], :new_thread, threads)

--- a/lib/rake/thread_history_display.rb
+++ b/lib/rake/thread_history_display.rb
@@ -1,8 +1,11 @@
+require 'rake/private_reader'
+
 module Rake
 
   class ThreadHistoryDisplay    # :nodoc: all
-    attr_reader :stats, :items, :threads
-    private :stats, :items, :threads
+    include Rake::PrivateReader
+
+    private_reader :stats, :items, :threads
 
     def initialize(stats)
       @stats   = stats

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -55,7 +55,7 @@ module Rake
       promise_worker = lambda do
         # assume someone else is executing this if the lock
         # has been obtained elsewhere
-         next if !promise_mutex.try_lock
+         next if ! promise_mutex.try_lock
          promise_core.call
          promise_mutex.unlock
       end
@@ -92,7 +92,7 @@ module Rake
     def join
       @threads_mon.synchronize do
         begin
-            @join_cond.wait unless @threads.empty?
+          @join_cond.wait unless @threads.empty?
         rescue Exception => e
           $stderr.puts e
           $stderr.print "Queue contains #{@queue.size} items. Thread pool contains #{@threads.count} threads\n"
@@ -146,7 +146,7 @@ module Rake
       stat :item_dequeued, :item_id => block.object_id
       block.call
       return true
-      
+
       rescue ThreadError # this means the queue is empty
       false
     end

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -119,9 +119,9 @@ module Rake
     # (see #gather_history). Best to call this when the job is
     # complete (i.e. after ThreadPool#join is called).
     def history                 # :nodoc:
-      @history_mon.synchronize { @history.dup }
-      .sort_by { |i| i[:time] }
-      .each { |i| i[:time] -= @history_start_time }
+      @history_mon.synchronize { @history.dup }.
+        sort_by { |i| i[:time] }.
+        each { |i| i[:time] -= @history_start_time }
     end
 
     # Return a hash of always collected statistics for the thread pool.

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -40,7 +40,7 @@ module Rake
 
       promise_core = lambda do
         # can't execute more than once
-        next unless promise_result.equal?(NOT_SET) && promise_error.equal?(NOT_SET)
+        next if promise_complete?(promise_result, promise_error)
         stat :promise_will_execute, :item_id => promise_worker.object_id
         begin
           promise_result = block.call(*local_args)
@@ -81,6 +81,11 @@ module Rake
       stat :item_queued, :item_id => promise_worker.object_id
       start_thread
       promise
+    end
+
+    def promise_complete?(promise_result, promise_error)
+      ! promise_result.equal?(NOT_SET) ||
+        ! promise_error.equal?(NOT_SET)
     end
 
     # Waits until the queue of futures is empty and all threads have exited.

--- a/test/test_private_reader.rb
+++ b/test/test_private_reader.rb
@@ -1,0 +1,42 @@
+require File.expand_path('../helper', __FILE__)
+require 'rake/private_reader'
+
+class TestPrivateAttrs < Rake::TestCase
+
+  class Sample
+    include Rake::PrivateReader
+
+    private_reader :reader, :a
+
+    def initialize
+      @reader = :RVALUE
+    end
+
+    def get_reader
+      reader
+    end
+
+  end
+
+  def setup
+    super
+    @sample = Sample.new
+  end
+
+  def test_private_reader_is_private
+    assert_private do @sample.reader end
+    assert_private do @sample.a end
+  end
+
+  def test_private_reader_returns_data
+    assert_equal :RVALUE, @sample.get_reader
+  end
+
+  private
+
+  def assert_private
+    ex = assert_raises(NoMethodError) do yield end
+    assert_match(/private/, ex.message)
+  end
+
+end

--- a/test/test_rake_thread_pool.rb
+++ b/test/test_rake_thread_pool.rb
@@ -69,7 +69,7 @@ class TestRakeTestThreadPool < Rake::TestCase
     }
 
     pool.join
-    assert_equal true, pool.__send__(:__queue__).empty?
+    assert_equal true, pool.__send__(:__queue__).empty?, "queue should be empty"
   end
 
   # test that throwing an exception way down in the blocks propagates

--- a/test/test_thread_history_display.rb
+++ b/test/test_thread_history_display.rb
@@ -64,7 +64,7 @@ class TestThreadHistoryDisplay < Rake::TestCase
     out, _ = capture_io do
       @display.show
     end
-    assert_match(/^ *1000000 +A +thread_deleted +deleted_thread:B +thread_count:12$/, out)
+    assert_match(/^ *1000000 +A +thread_deleted( +deleted_thread:B| +thread_count:12){2}$/, out)
   end
 
   def test_thread_created

--- a/test/test_thread_history_display.rb
+++ b/test/test_thread_history_display.rb
@@ -72,7 +72,7 @@ class TestThreadHistoryDisplay < Rake::TestCase
     out, _ = capture_io do
       @display.show
     end
-    assert_match(/^ *1000000 +A +thread_created +new_thread:B +thread_count:13$/, out)
+    assert_match(/^ *1000000 +A +thread_created( +new_thread:B| +thread_count:13){2}$/, out)
   end
 
   private


### PR DESCRIPTION
This is an interesting, but still experimental version of the ThreadPool in
which the thread pool no longer needs to create new threads to
compensate for the imminent sleep of a thread on a future.

Previously, the ThreadPool created futures and added them to the queue.
If, when they processed a future and they had to wait for it to
finish executing, they would spawn another thread so they could
wait for the future.

Now, a non-blocking attempt to process the future's block is what is
put on the queue and a blocking attempt is passed back from #future.
In this way, the thread pool is free to process the core of a future
by dequeuing it and calling it. The the thread can't get the lock, it
is assumed that another thread is handling it and so it moves to
the next.
