### PR TITLE
Fix Application#trace which would interleave CR in a multi-threaded context

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -316,7 +316,19 @@ module Rake
 
     def trace(*str)
       options.trace_output ||= $stderr
-      options.trace_output.puts(*str)
+
+      # use the same semantics as puts, but use print and append a CR to the end to
+      # make sure the entire string is output as a single unit.
+      sep = ($\||"\n")
+      if str.empty?
+        options.trace_output.print sep
+      else
+        msgs = str.flatten.collect do |m|
+          next m + sep if m.is_a?(String) && !m.end_with?("\n")
+          m
+        end
+        options.trace_output.print(*msgs)
+      end
     end
 
     def sort_options(options)


### PR DESCRIPTION
Running rake with tracing on and executing multitasks would show
a trace with multiple traces on a single line and other lines having
multiple CRs. This is because `#trace` used `IO#puts` behind the scenes.

`IO#puts` first calls `IO#write` with the string, followed by another `IO#write`
with the CR. Because of the gap in-between calls, another thread
could sneak in a CR or another string.

The fix is to make sure calls to `Application#trace` create a single string with
a CR appended before calling `IO#print`. This will output a single
string with a trailing CR in thread-safe way.

Example output showing the error:

```
** Execute 98** Execute 68** Execute 69

** Execute 74

** Execute 78** Execute 81
** Execute 84** Execute 100

** Execute 89
```
