### PR TITLE
Support variable-length arguments for Tasks

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -251,6 +251,25 @@ for tasks with arguments.  For example:
      puts "Last  name is #{args.last_name}"
    end
 
+=== Tasks that take Variable-length Parameters
+
+Tasks that need to handle a list of values as a parameter can use the
+extras method of the args variable.  This allows for tasks that can
+loop over a variable number of values, and its compatible with named
+parameters as well:
+
+   task :email, [:message] do |t, args|
+     mail = Mail.new(args.message)
+     recipients = args.extras
+     recipients.each do |target|
+       mail.send_to(recipents)
+     end
+   end
+
+There is also the convenience method to_a that returns all parameters
+in the sequential order they were given, including those associated 
+with named parameters.
+
 === Deprecated Task Parameters Format
 
 There is an older format for declaring task parameters that omitted

--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -15,16 +15,27 @@ module Rake
       @names = names
       @parent = parent
       @hash = {}
+      @values = values
       names.each_with_index { |name, i|
         @hash[name.to_sym] = values[i] unless values[i].nil?
       }
+    end
+
+    # Retrive the complete array of sequential values
+    def to_a
+      @values.dup
+    end
+
+    # Retrive the list of values not associated with named arguments
+    def extras
+      @values[@names.length..-1] || []
     end
 
     # Create a new argument scope using the prerequisite argument
     # names.
     def new_scope(names)
       values = names.collect { |n| self[n] }
-      self.class.new(names, values, self)
+      self.class.new(names, values+self.extras, self)
     end
 
     # Find an argument value by name or index.

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -85,4 +85,34 @@ class TestRakeTaskArguments < Rake::TestCase
     ta.with_defaults({ "cc" => "default_val" })
     assert_nil ta[:cc]
   end
+
+  def test_all_and_extra_arguments_without_named_arguments
+    app = Rake::Application.new
+    ta = Rake::TaskArguments.new([],app.parse_task_string("task[1,two,more]").last)
+    assert_equal [], ta.names
+    assert_equal ['1','two','more'], ta.to_a
+    assert_equal ['1','two','more'], ta.extras
+  end
+
+  def test_all_and_extra_arguments_with_named_arguments
+    app = Rake::Application.new
+    ta = Rake::TaskArguments.new([:first,:second],app.parse_task_string("task[1,two,more,still more]").last)
+    assert_equal [:first,:second], ta.names
+    assert_equal "1", ta[:first]
+    assert_equal "two", ta[:second]
+    assert_equal ['1','two','more','still more'], ta.to_a
+    assert_equal ['more','still more'], ta.extras
+  end
+
+  def test_extra_args_with_less_than_named_arguments
+    app = Rake::Application.new
+    ta = Rake::TaskArguments.new([:first,:second,:third],app.parse_task_string("task[1,two]").last)
+    assert_equal [:first,:second,:third], ta.names
+    assert_equal "1", ta[:first]
+    assert_equal "two", ta[:second]
+    assert_equal nil, ta[:third]
+    assert_equal ['1','two'], ta.to_a
+    assert_equal [], ta.extras
+  end
+
 end


### PR DESCRIPTION
As an alternative implementation to https://github.com/jimweirich/rake/pull/70, this allows tasks to access parameters beyond the named parameters that are currently supported.  This is accomplished by storing the sequential list of values provided as arguments to the task, and making them available to the block via args.extras.

I have encountered the need for iterating over a variable number of values in a task many times, such as this contrived example below:

``` ruby
desc "Send a message to one or more recipients"
task :email, [:message] do |t, args|
  mail = Mail.new(args.message)
  recipients = args.extras
  recipients.each do |target|
    mail.send_to(recipent)
  end
end
```

It remains compatible with the current named argument and prerequisites syntax using the arrow notation, and doesn't create any further auto-generated hash keys.

It also adds a to_a method to provide the full list of values passed in, regardless whether they are associated with a named argument or not.
