### PR TITLE
Default thread pool size

### DIFF
--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -63,7 +63,7 @@ Options are:
 
     Sample values:
      (no -j) : 2 concurrent tasks (exact number may change)
-     -j      : 2 concurrent tasks (exact number may change)
+     -j      : unlimited concurrent tasks (standard rake behavior)
      -j 16   : 16 concurrent tasks
 
 [<tt>--job-stats</tt> _level_]

--- a/doc/command_line_usage.rdoc
+++ b/doc/command_line_usage.rdoc
@@ -62,7 +62,7 @@ Options are:
     multitasks.
 
     Sample values:
-     (no -j) : unlimited concurrent tasks (standard rake behavior)
+     (no -j) : 2 concurrent tasks (exact number may change)
      -j      : 2 concurrent tasks (exact number may change)
      -j 16   : 16 concurrent tasks
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -386,7 +386,7 @@ module Rake
           ],
           ['--jobs',  '-j [NUMBER]',
             "Specifies the maximum number of tasks to execute in parallel. (default:2)",
-            lambda { |value| options.thread_pool_size = [(value || 2).to_i,2].max }
+            lambda { |value| options.thread_pool_size =  value ? [value.to_i,2].max : nil }
           ],
           ['--job-stats [LEVEL]',
             "Display job statistics. LEVEL=history displays a complete job list",

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -523,6 +523,7 @@ module Rake
     # Read and handle the command line options.
     def handle_options
       options.rakelib = ['rakelib']
+      options.thread_pool_size = 2
       options.trace_output = $stderr
 
       OptionParser.new do |opts|

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -117,11 +117,14 @@ class TestRakeApplicationOptions < Rake::TestCase
     flags(['--jobs', '4'], ['-j', '4']) do |opts|
       assert_equal 4, opts.thread_pool_size
     end
+    flags(['--jobs', '0'], ['-j', '0']) do |opts|
+      assert_equal 2, opts.thread_pool_size
+    end
     flags(['--jobs', 'asdas'], ['-j', 'asdas']) do |opts|
       assert_equal 2, opts.thread_pool_size
     end
     flags('--jobs', '-j') do |opts|
-      assert_equal 2, opts.thread_pool_size
+      assert_nil opts.thread_pool_size
     end
   end
 

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -42,7 +42,7 @@ class TestRakeApplicationOptions < Rake::TestCase
     assert_nil opts.show_tasks
     assert_nil opts.silent
     assert_nil opts.trace
-    assert_nil opts.thread_pool_size
+    assert_equal 2, opts.thread_pool_size
     assert_equal ['rakelib'], opts.rakelib
     assert ! Rake::FileUtilsExt.verbose_flag
     assert ! Rake::FileUtilsExt.nowrite_flag


### PR DESCRIPTION
This fixes issue #154.

I've included two separate, but related commits in this pull request.  The first just changes the default thread_pool_size when -j/--jobs is not specified on the command-line to 2.  The second also changes the thread_pool_size when -j is specified with no value so that it uses an "unlimited" number of threads.

The rationale is that an unfamiliar Rakefile might use MultiTasks that result in too many jobs for a system.  With this change, an unsuspecting or forgetful user of the Rakefile won't get burned by this when just typing "rake" on the command line.  

The second commit allows a knowledgeable user to obtain the old default behavior of "unlimited" threads without having to specify a numeric argument to -j/--jobs.
