### PR TITLE
handle nil objects in the output strings so the correct stack trace can be shown

### DIFF
--- a/lib/rake/trace_output.rb
+++ b/lib/rake/trace_output.rb
@@ -11,7 +11,7 @@ module Rake
       if strings.empty?
         output = sep
       else
-        output = strings.map { |s| s.end_with?(sep) ? s : s + sep }.join
+        output = strings.map { |s| s.nil? || s.end_with?(sep) ? s : s + sep }.join
       end
       out.print(output)
     end


### PR DESCRIPTION
Some gem (thrift 0.08) returns nil objects for the output strings, and cause stack trace incorrectly showing errors in rake.
