### PR TITLE
Fix hypothetical Java example

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -337,7 +337,7 @@ required on *rule* when the first argument is a regular expression.
 
 The following rule might be used for Java files ...
 
-  rule '.java' => [
+  rule '.class' => [
     proc { |tn| tn.sub(/\.class$/, '.java').sub(/^classes\//, 'src/') }
   ] do |t|
     java_compile(t.source, t.name)


### PR DESCRIPTION
The documentation had an example rule for a hypothetical compile of
a .java file that would compile down to a .class file, but the
example began with:

```
rule '.java' => ...
```

Since the extension after 'rule' is supposed to be the target
extension rather than the source extension, it should begin with:

```
rule '.class' => ...
```
