### PR TITLE
Correcting PseudoStatus namespace in rake/file_utils.rb

### DIFF
--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -41,7 +41,7 @@ module FileUtils
     unless options[:noop]
       res = rake_system(*cmd)
       status = $?
-      status = PseudoStatus.new(1) if !res && status.nil?
+      status = Rake::PseudoStatus.new(1) if !res && status.nil?
       shell_runner.call(res, status)
     end
   end


### PR DESCRIPTION
Just a missing namespace.

I don't expect many people find themselves in a situation where their shell command returns nothing and has no return value (`if !res && status.nil?`), but somehow I did. I'm not even sure how to emulate that scenario, otherwise there would have been a test included.
