### PR TITLE
Typo: 'should be used with cation' for 'caution'

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -291,7 +291,7 @@ Running this example:
 
 The ability to programmatically manipulate tasks gives rake very
 powerful meta-programming capabilities w.r.t. task execution, but
-should be used with cation.
+should be used with caution.
 
 == Rules
 


### PR DESCRIPTION
Just a small typo.
