### PR TITLE
Allow to pass multiline ENV-like arguments

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -625,7 +625,7 @@ module Rake
     def collect_tasks
       @top_level_tasks = []
       ARGV.each do |arg|
-        if arg =~ /^(\w+)=(.*)$/
+        if arg =~ /^(\w+)=(.*)$/m
           ENV[$1] = $2
         else
           @top_level_tasks << arg unless arg =~ /^-/


### PR DESCRIPTION
It would be very useful if rake would allow the user to pass multiline arguments, that could be parsed inside the task, for example:

```
$ rake some:task YAML_ARGS='

---
:a: foo
:b: bar
'
```

The only needed change is adding the `m` flag to the RegExp that parses the ARGV. 
