### PR TITLE
convert win32 directory separator "\\" to "/".

### DIFF
--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -5,6 +5,7 @@ module Rake
                                  keys.grep(/(prefix|libdir)/)).uniq + [
         File.join(File.dirname(__FILE__), ".."),
       ].map { |f| Regexp.quote(File.expand_path(f)) }
+    SUPPRESSED_PATHS.map! { |s| s.gsub("\\", "/") }
     SUPPRESSED_PATHS.reject! { |s| s.nil? || s =~ /^ *$/ }
 
     SUPPRESS_PATTERN = %r!(\A#{SUPPRESSED_PATHS.join('|')}|bin/rake:\d+)!i


### PR DESCRIPTION
convert win32 directory separator "\" to "/".

%r!#{["e:\xpgs\jruby", 'other'].join '|'}!
ArgumentError: invalid hex escape
