### PR TITLE
Add Rake::Task#prerequisite_tasks!

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -61,6 +61,16 @@ module Rake
     end
     private :lookup_prerequisite
 
+    def prerequisite_tasks!(limit=30)
+      self.prerequisite_tasks.inject([]) do |tasks, task|
+        tasks << task
+        unless task.prerequisite_tasks.empty? or limit < 1
+          tasks += task.prerequisite_tasks!(limit - 1)
+        end
+        tasks
+      end
+    end
+
     # First source from a rule (nil if no sources)
     def source
       @sources.first if defined?(@sources)

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -61,6 +61,9 @@ module Rake
     end
     private :lookup_prerequisite
 
+    # Complete list of prerequisite tasks including subtask's prerequisites
+    # recursively until no prerequisites exist or depth +limit+ reached.
+    # Default +limit+ is 30.
     def prerequisite_tasks!(limit=30)
       self.prerequisite_tasks.inject([]) do |tasks, task|
         tasks << task

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -61,18 +61,20 @@ module Rake
     end
     private :lookup_prerequisite
 
-    # Complete list of prerequisite tasks including subtask's prerequisites
-    # recursively until no prerequisites exist or depth +limit+ reached.
-    # Default +limit+ is 30.
-    def prerequisite_tasks!(limit=30)
-      self.prerequisite_tasks.inject([]) do |tasks, task|
-        tasks << task
-        unless task.prerequisite_tasks.empty? or limit < 1
-          tasks += task.prerequisite_tasks!(limit - 1)
-        end
-        tasks
-      end
+    # List of all unique prerequisite tasks including prerequisite tasks'
+    # prerequisites.
+    # Includes self when cyclic dependencies are found.
+    def all_prerequisite_tasks
+      fetch_prerequisites
     end
+
+    def fetch_prerequisites(list=[])
+      prerequisite_tasks.each do |pre|
+        list << pre and pre.fetch_prerequisites(list) unless list.include?(pre)
+      end unless prerequisite_tasks.empty?
+      list
+    end
+    protected :fetch_prerequisites
 
     # First source from a rule (nil if no sources)
     def source

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -220,6 +220,33 @@ class TestRakeTask < Rake::TestCase
     assert_equal [b, c], a.prerequisite_tasks
   end
 
+  def test_deep_prerequisite_tasks_includes_deep_prerequisites
+    a = task :a => ["b", "d"]
+    b = task :b => "c"
+    c = task :c
+    d = task :d
+
+    assert_equal [b, c, d], a.prerequisite_tasks!
+  end
+
+  def test_deep_prerequisite_tasks_honors_limit
+    a = task :a => "b"
+    b = task :b => "c"
+    c = task :c => "a"
+
+    assert a.prerequisite_tasks!.include?(a)
+    assert a.prerequisite_tasks!.include?(b)
+    assert a.prerequisite_tasks!.include?(c)
+  end
+
+  def test_deep_prerequisite_tasks_includes_duplicates
+    a = task :a => ["b", "c"]
+    b = task :b => "c"
+    c = task :c
+
+    assert_equal [b, c, c], a.prerequisite_tasks!
+  end
+
   def test_timestamp_returns_now_if_all_prereqs_have_no_times
     a = task :a => ["b", "c"]
     task :b

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -220,31 +220,29 @@ class TestRakeTask < Rake::TestCase
     assert_equal [b, c], a.prerequisite_tasks
   end
 
-  def test_deep_prerequisite_tasks_includes_deep_prerequisites
-    a = task :a => ["b", "d"]
-    b = task :b => "c"
-    c = task :c
-    d = task :d
-
-    assert_equal [b, c, d], a.prerequisite_tasks!
-  end
-
-  def test_deep_prerequisite_tasks_honors_limit
+  def test_all_prerequisite_tasks_includes_all_prerequisites
     a = task :a => "b"
-    b = task :b => "c"
-    c = task :c => "a"
+    b = task :b => ["c", "d"]
+    c = task :c => "e"
+    d = task :d
+    e = task :e
 
-    assert a.prerequisite_tasks!.include?(a)
-    assert a.prerequisite_tasks!.include?(b)
-    assert a.prerequisite_tasks!.include?(c)
+    assert_equal [b, c, d, e], a.all_prerequisite_tasks.sort_by { |t| t.name }
   end
 
-  def test_deep_prerequisite_tasks_includes_duplicates
+  def test_all_prerequisite_tasks_does_not_include_duplicates
     a = task :a => ["b", "c"]
     b = task :b => "c"
     c = task :c
 
-    assert_equal [b, c, c], a.prerequisite_tasks!
+    assert_equal [b, c], a.all_prerequisite_tasks.sort_by { |t| t.name }
+  end
+
+  def test_all_prerequisite_tasks_includes_self_on_cyclic_dependencies
+    a = task :a => "b"
+    b = task :b => "a"
+
+    assert_equal [a, b], a.all_prerequisite_tasks.sort_by { |t| t.name }
   end
 
   def test_timestamp_returns_now_if_all_prereqs_have_no_times


### PR DESCRIPTION
Add `Rake::Task#prerequisite_tasks!` method to return a full list of prerequisite tasks from the receiver tasks and its prerequisite tasks tasks, recursively.

This is usefull if one needs to call reenable on a task and all of its prerequisite tasks, not just direct ones.
As a use case example, when writing integration tests for rake tasks it is common to call `Rake::Task#reenable` before or after every `Rake::Task#invoke`.
If the task has prerequisites they will not be invoked beyond the first call because they are not affected by #reenable. Calling #reenable on every task's prerequisite task can be done with just `Rake::Task[task].prerequisite_tasks.each(&:reenable)`
but that is not so simple when those prerequisites have themselves prerequisite tasks, that's when this comes in handy.
I hope the example is clear enough.

Other alternatives for the method name may be `#deep_prerequisite_tasks` based on `#deep_clone` or `#deep_copy`.

The implementation proposed sets a default depth limit of 30 to avoid circular dependency(SystemStackError: stack level too deep).
