### PR TITLE
Rakefile doc: added section on rakefile path, added note on environment variables.

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -80,7 +80,7 @@ method).  In addition, file tasks are usually named with a string
 rather than a symbol.
 
 The following file task creates a executable program (named +prog+)
-given two object files name <tt>a.o</tt> and <tt>b.o</tt>.  The tasks
+given two object files named <tt>a.o</tt> and <tt>b.o</tt>.  The tasks
 for creating <tt>a.o</tt> and <tt>b.o</tt> are not shown.
 
   file "prog" => ["a.o", "b.o"] do |t|
@@ -196,9 +196,23 @@ or
 
    RELEASE_VERSION=0.8.2 rake release
 
+or, alternatively 
+
+   rake release RELEASE_VERSION=0.8.2
+
 will work.  Environment variable names must either match the task
 parameter exactly, or match an all-uppercase version of the task
 parameter.
+
+<b>NOTE:</b> A variable declared within a rake command will
+not persist in the environment:
+
+   $ export $VALUE=old
+   $ rake :print_value $VALUE=new
+   new
+
+   $ rake :print_value  
+   old
 
 === Tasks that Expect Parameters
 

--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -4,7 +4,6 @@ First of all, there is no special format for a Rakefile.  A Rakefile
 contains executable Ruby code.  Anything legal in a ruby script is
 allowed in a Rakefile.
 
-
 Now that we understand there is no special syntax in a Rakefile, there
 are some conventions that are used in a Rakefile that are a little
 unusual in a typical Ruby program.  Since a Rakefile is tailored to
@@ -208,10 +207,10 @@ parameter.
 not persist in the environment:
 
    $ export $VALUE=old
-   $ rake :print_value $VALUE=new
+   $ rake print_value $VALUE=new
    new
 
-   $ rake :print_value  
+   $ rake print_value  
    old
 
 === Tasks that Expect Parameters
@@ -567,11 +566,11 @@ This is the proper way to specify the task ...
 
 == Rakefile Path
 
-When issuing the <tt>rake<tt> command in a terminal, Rake will look 
+When issuing the <tt>rake</tt> command in a terminal, Rake will look 
 for a Rakefile in the current directory. If a Rakefile  is not found, 
 it will search parent directories until one is found.
 
-For example, if a Rakefile resides in the <tt>project/<tt> directory, 
+For example, if a Rakefile resides in the <tt>project/</tt> directory, 
 moving deeper into the project's directory tree will not have an adverse
 effect on rake tasks:
 
@@ -590,7 +589,7 @@ which the Rakefile resides.
 
 === Multiple Rake Files
 
-Not all tasks need to be included in a single Rakefile. A <tt>rakelib<tt>
+Not all tasks need to be included in a single Rakefile. A <tt>rakelib</tt>
 directory may be created for including additional Rake files.
 
 ----

--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -207,9 +207,8 @@ parameter.
 not persist in the environment:
 
    $ export $VALUE=old
-   $ rake print_value $VALUE=new
+   $ rake print_value VALUE=new
    new
-
    $ rake print_value  
    old
 

--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -4,6 +4,7 @@ First of all, there is no special format for a Rakefile.  A Rakefile
 contains executable Ruby code.  Anything legal in a ruby script is
 allowed in a Rakefile.
 
+
 Now that we understand there is no special syntax in a Rakefile, there
 are some conventions that are used in a Rakefile that are a little
 unusual in a typical Ruby program.  Since a Rakefile is tailored to
@@ -549,6 +550,34 @@ This is the proper way to specify the task ...
   file "prog" => object_files do
     # Actions go here
   end
+
+== Rakefile Path
+
+When issuing the <tt>rake<tt> command in a terminal, Rake will look 
+for a Rakefile in the current directory. If a Rakefile  is not found, 
+it will search parent directories until one is found.
+
+For example, if a Rakefile resides in the <tt>project/<tt> directory, 
+moving deeper into the project's directory tree will not have an adverse
+effect on rake tasks:
+
+  $ pwd
+  /home/user/project
+
+  $ cd lib/foo/bar
+  $ pwd
+  /home/user/project/lib/foo/bar
+
+  $ rake run_pwd
+  /home/user/project
+
+As far as rake is concerned, all tasks are run from the directory in 
+which the Rakefile resides.
+
+=== Multiple Rake Files
+
+Not all tasks need to be included in a single Rakefile. A <tt>rakelib<tt>
+directory may be created for including additional Rake files.
 
 ----
 


### PR DESCRIPTION
Hi!

I updated the Rakefile doc with the following:
- I added a section about where to place Rakefiles. (I've not seen this mentioned in the Rake tutorials I've read around the web.)
- I expanded the example in the "Arguments and the Environment" section and added a note on environment variable persistence. 
- I fixed some of my own typos :confused: 

Hope it's useful. Thanks.
