### PR TITLE
remove_task

### DIFF
--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -32,6 +32,15 @@ module Rake
       Rake::Task.define_task(*args, &block)
     end
 
+    # Remove a task.
+    #
+    # Example:
+    #   old = remove_task :foo
+    #
+    def remove_task(name)
+      Rake.application.instance_variable_get(:@tasks).delete(name.to_str)
+    end
+
     # Declare a file task.
     #
     # Example:

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -37,4 +37,12 @@ class TestRakeDsl < Rake::TestCase
     assert ! defined?(Commands), "should not define Commands"
   end
 
+  def test_remove_task
+    task "soon-gone"
+    assert Rake::Task.task_defined?("soon-gone")
+
+    remove_task "soon-gone"
+    refute Rake::Task.task_defined?("soon-gone")
+  end
+
 end


### PR DESCRIPTION
@jimweirich
In a crazy complex task framework like rails, a task that does not work for your environment is a pretty bad showstopper, since it cannot easily be overwritten, just appended to. So let us add a nice syntax for removal of tasks. Judging from the amount of blogs/stackoverflows etc on this topic that I'd say there is a decent demand for this feature.
