### PR TITLE
Ruby 1.8.6 support

### DIFF
--- a/lib/rake/trace_output.rb
+++ b/lib/rake/trace_output.rb
@@ -13,7 +13,7 @@ module Rake
       else
         output = strings.map { |s|
           next if s.nil?
-          s.end_with?(sep) ? s : s + sep
+          s =~ /#{sep}$/ ? s : s + sep
         }.join
       end
       out.print(output)


### PR DESCRIPTION
In Readme file you wrote:
**Requires Ruby 1.8.6 or later**
But, in _trace_output.rb_ you use **end_with?** ruby String method, that isn't supported at Ruby 1.8.6

Sorry, but I can't update my ruby version on server now.
