### PR TITLE
Removed useless `begin` and `end` for exceptions inside the method

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -156,19 +156,17 @@ module Rake
 
     # Provide standard exception handling for the given block.
     def standard_exception_handling
-      begin
-        yield
-      rescue SystemExit => ex
-        # Exit silently with current status
-        raise
-      rescue OptionParser::InvalidOption => ex
-        $stderr.puts ex.message
-        exit(false)
-      rescue Exception => ex
-        # Exit with error message
-        display_error_message(ex)
-        exit_because_of_exception(ex)
-      end
+      yield
+    rescue SystemExit => ex
+      # Exit silently with current status
+      raise
+    rescue OptionParser::InvalidOption => ex
+      $stderr.puts ex.message
+      exit(false)
+    rescue Exception => ex
+      # Exit with error message
+      display_error_message(ex)
+      exit_because_of_exception(ex)
     end
 
     # Exit the program because of an unhandle exception.


### PR DESCRIPTION
According this style guide https://github.com/bbatsov/ruby-style-guide#exceptions.
Section **Use implicit begin blocks where possible**.
