### PR TITLE
escape backslash twice to get the intended effect in backtrace suppression

### DIFF
--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -5,7 +5,7 @@ module Rake
                                  keys.grep(/(prefix|libdir)/)).uniq + [
         File.join(File.dirname(__FILE__), ".."),
       ].map { |f| Regexp.quote(File.expand_path(f)) }
-    SUPPRESSED_PATHS.map! { |s| s.gsub("\\", "/") }
+    SUPPRESSED_PATHS.map! { |s| s.gsub("\\\\", "/") }
     SUPPRESSED_PATHS.reject! { |s| s.nil? || s =~ /^ *$/ }
 
     SUPPRESS_PATTERN = %r!(\A#{SUPPRESSED_PATHS.join('|')}|bin/rake:\d+)!i


### PR DESCRIPTION
This commit https://github.com/jimweirich/rake/commit/e963112dfea1ae902784468894c93c460331abb3 subbed single backslashes with forward slashes, which results in odd behavior. When a test task fails, it doesn't suppress the backtrace. It looks like jimweirich/rake#23. The reason is because when Backtrace is in an installed gem, the path has dots in it, which are escaped, but the gsub removes the escape slashes and replaces them with forward slashes.

This changes it to replace `\\` with `/` 

to reproduce, install the latest version of rake and run a failing test suite using the test task. You'll see a long stack trace like in jimweirich/rake#23
