### PR TITLE
Change the OptParser banner to use Rake.application.name.

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -572,7 +572,7 @@ module Rake
       options.trace_output = $stderr
 
       OptionParser.new do |opts|
-        opts.banner = "rake [-f rakefile] {options} targets..."
+        opts.banner = "#{Rake.application.name} [-f rakefile] {options} targets..."
         opts.separator ""
         opts.separator "Options are ..."
 


### PR DESCRIPTION
This allows subclasses of `Rake::Application` (such as Capistrano) to identify
themselves correctly when being used with the `--help` (or with incorrect)
flags.

This small change has not mandated any additional test coverage, and has not
broken the tests for me.
