### PR TITLE
Regenerate and reload any imported files.

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -716,6 +716,11 @@ module Rake
         ext = File.extname(fn)
         loader = @loaders[ext] || @default_loader
         loader.load(fn)
+        if fn_task = lookup(fn) and fn_task.needed?
+          fn_task.reenable
+          fn_task.invoke
+          loader.load(fn)
+        end
         @imported << fn
       end
     end

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -217,6 +217,30 @@ default: other
     end
   end
 
+  def rakefile_regenerate_imports
+    rakefile <<-REGENERATE_IMPORTS
+task :default
+
+task :regenerate do
+  open("deps", "w") do |f|
+    f << <<-CONTENT
+file "deps" => :regenerate
+puts "REGENERATED"
+    CONTENT
+  end
+end
+
+import "deps"
+    REGENERATE_IMPORTS
+
+    open "deps", "w" do |f|
+      f << <<-CONTENT
+file "deps" => :regenerate
+puts "INITIAL"
+      CONTENT
+    end
+  end
+
   def rakefile_multidesc
     rakefile <<-MULTIDESC
 task :b

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -500,14 +500,12 @@ class TestRakeApplication < Rake::TestCase
 
     loader.instance_variable_set :@load_called, false
     def loader.load arg
-      raise 'called more than once' if @load_called
       raise ArgumentError, arg unless arg == 'x.dummy'
       @load_called = true
     end
 
     loader.instance_variable_set :@make_dummy_called, false
     def loader.make_dummy
-      raise 'called more than once' if @make_dummy_called
       @make_dummy_called = true
     end
 

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -268,6 +268,14 @@ class TestRakeFunctional < Rake::TestCase
     assert_match(/^FIRST$\s+^DYNAMIC$\s+^STATIC$\s+^OTHER$/, @out)
   end
 
+  def test_regenerate_imports
+    rakefile_regenerate_imports
+
+    rake
+
+    assert_match(/^INITIAL\s+^REGENERATED$/, @out)
+  end
+
   def test_rules_chaining_to_file_task
     rakefile_chains
 


### PR DESCRIPTION
In some cases, loading an imported file will modify the task that generates that file.  However, since that task was already invoked prior to the import, it will not be re-invoked.  This can result in the imported file never being re-generated.

Consider building a C program with Rake.  We might have a task to generate the dependencies for each of the .c files and then import those dependencies.  In the main `Rakefile`, we know that `foo.d` depends on `foo.c`, but we don't yet know that `foo.d` also depends on `foo.h` until we import `foo.d`.  If `foo.h` changes, `foo.d` should be re-generated, but it never will be, because once we know about the new dependency, `foo.d`'s file task has already been executed.

I'm pretty sure there's a better way to implement the solution for this problem; what I have here works, but broke another test until I removed some guards from `util_loader`.  Please feel free to come up with a better solution.  I have included a new functional test that fails without a solution to this issue.
