### PR TITLE
Better rake task argument parser that accepts commas in argument values

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -150,19 +150,21 @@ module Rake
     end
 
     def parse_task_string(string)
-      @token_re ||= /((?:[^\\,]|\\.)*)(?:,(.*))?$/
       if string =~ /^([^\[]+)(\[(.*)\])$/
         name = $1
         args = []
 
         if $2 != '[]'
-          match_data = @token_re.match($3)
-          while !match_data.nil?
-            token, rest = match_data[1].strip, match_data[2]
+          # there's at least one non-empty argument
+          remaining_args = $3
+          begin
+            # extract the first argument
+            match_data = /((?:[^\\,]|\\.)*)(?:,(.*))?$/.match(remaining_args)
+            token, remaining_args = match_data[1].strip, match_data[2]
+
+            # strip backslashes and take the argument
             args << (token.gsub!(/\\(.)/, '\1') || token)
-            break if rest.nil?
-            match_data = @token_re.match(rest)
-          end
+          end until remaining_args.nil?
         end
       else
         name = string

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -150,9 +150,20 @@ module Rake
     end
 
     def parse_task_string(string)
+      @token_re ||= /((?:[^\\,]|\\.)*)(?:,(.*))?$/
       if string =~ /^([^\[]+)(\[(.*)\])$/
         name = $1
-        args = $3.split(/\s*,\s*/)
+        args = []
+
+        if $2 != '[]'
+          match_data = @token_re.match($3)
+          while !match_data.nil?
+            token, rest = match_data[1].strip, match_data[2]
+            args << (token.gsub!(/\\(.)/, '\1') || token)
+            break if rest.nil?
+            match_data = @token_re.match(rest)
+          end
+        end
       else
         name = string
         args = []

--- a/test/test_rake_task_argument_parsing.rb
+++ b/test/test_rake_task_argument_parsing.rb
@@ -43,6 +43,12 @@ class TestRakeTaskArgumentParsing < Rake::TestCase
     assert_equal ["a one ana", "two"], args
   end
 
+  def test_can_handle_commas_in_args
+    name, args = @app.parse_task_string("name[one, two, three_a\\, three_b, four]")
+    assert_equal "name", name
+    assert_equal ["one", "two", "three_a, three_b", "four"], args
+  end
+
   def test_terminal_width_using_env
     app = Rake::Application.new
     app.terminal_columns = 1234


### PR DESCRIPTION
Current rake task argument parser does not allow arguments to contain commas. This is a pain if one needs to pass such arguments to the rake tasks and users may tend to ugly workarounds such as using a helper character that's later replaced with a comma.

This commit improves the parser so that arguments could contain escaped commas in their values. A backslash is used as the escape character. All escaped characters are passed to the rake tasks as if they were not escaped (i.e. not only commas but any character can be escaped).

Example:
[a\b\\c\,de,fgh] will be interpreted as two arguments "ab\c,de" and "fgh".
