### PR TITLE
Make Task#source default to the first prerequisite in non-rule tasks.

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -74,7 +74,11 @@ module Rake
 
     # First source from a rule (nil if no sources)
     def source
-      @sources.first if defined?(@sources)
+      if defined?(@sources)
+        @sources.first
+      else
+        prerequisites.first
+      end
     end
 
     # Create a task named +task_name+ with no actions or prerequisites. Use

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -41,7 +41,11 @@ module Rake
     # List of sources for task.
     attr_writer :sources
     def sources
-      @sources ||= []
+      if defined?(@sources)
+        @sources
+      else
+        prerequisites
+      end
     end
 
     # List of prerequisite tasks
@@ -74,11 +78,7 @@ module Rake
 
     # First source from a rule (nil if no sources)
     def source
-      if defined?(@sources)
-        @sources.first
-      else
-        prerequisites.first
-      end
+      sources.first
     end
 
     # Create a task named +task_name+ with no actions or prerequisites. Use

--- a/test/test_rake_file_task.rb
+++ b/test/test_rake_file_task.rb
@@ -98,6 +98,11 @@ class TestRakeFileTask < Rake::TestCase
     assert @ran
   end
 
+  def test_source_is_first_prerequisite
+    t = file :f => ["preqA", "preqB"]
+    assert_equal "preqA", t.source
+  end
+
   # I have currently disabled this test.  I'm not convinced that
   # deleting the file target on failure is always the proper thing to
   # do.  I'm willing to hear input on this topic.

--- a/test/test_rake_file_task.rb
+++ b/test/test_rake_file_task.rb
@@ -103,6 +103,11 @@ class TestRakeFileTask < Rake::TestCase
     assert_equal "preqA", t.source
   end
 
+  def test_sources_is_all_prerequisites
+    t = file :f => ["preqA", "preqB"]
+    assert_equal ["preqA", "preqB"], t.sources
+  end
+
   # I have currently disabled this test.  I'm not convinced that
   # deleting the file target on failure is always the proper thing to
   # do.  I'm willing to hear input on this topic.

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -373,4 +373,9 @@ class TestRakeTask < Rake::TestCase
     task(:t)
     assert_equal "line one / line two", t.comment
   end
+
+  def test_source_is_first_prerequisite
+    t = task :t => ["preqA", "preqB"]
+    assert_equal "preqA", t.source
+  end
 end


### PR DESCRIPTION
In GNU Make, The `$<` macro always expands to the _first_ prerequisite of the current rule. This supports a common idiom wherein the primary "source file" for the target is listed first in the dependency list.

The Rake analog of this macro seems to be `Task#source`, but unlike in Make it is only available in tasks declared with `rule`.

Making `Task#source` return the first prerequisite in non-rule tasks aids code malleability. Let's say I start with a file task:

``` ruby
file "ch1.html" => ["ch1.md"] do |t|
  sh "pandoc -o #{t.name} #{t.source}"
end
```

I can then generalize it into a rule without changing the body at all:

``` ruby
rule ".html" => [".md"] do |t|
  sh "pandoc -o #{t.name} #{t.source}"
end
```

What do you think?
