### PR TITLE
Enable rules to accept Method object as prerequisites.

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -265,7 +265,7 @@ module Rake
           task_name.ext(ext)
         when String
           ext
-        when Proc
+        when Proc, Method
           if ext.arity == 1
             ext.call(task_name)
           else

--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -359,4 +359,30 @@ class TestRakeRules < Rake::TestCase
     Task[OBJFILE].invoke('arg')
   end
 
+  def test_rule_with_method_prereq
+    create_file(".foo")
+    obj = Object.new
+    def obj.find_prereq
+      ".foo"
+    end
+    rule '.o' => obj.method(:find_prereq) do |t|
+      @runs << "#{t.name} - #{t.source}"
+    end
+    Task[OBJFILE].invoke
+    assert_equal ["#{OBJFILE} - .foo"], @runs
+  end
+
+  def test_rule_with_one_arg_method_prereq
+    create_file(SRCFILE)
+    obj = Object.new
+    def obj.find_prereq(task_name)
+      task_name.ext(".c")
+    end
+    rule '.o' => obj.method(:find_prereq) do |t|
+      @runs << "#{t.name} - #{t.source}"
+    end
+    Task[OBJFILE].invoke
+    assert_equal ["#{OBJFILE} - abc.c"], @runs
+  end
+
 end


### PR DESCRIPTION
I have this rule:

``` ruby
rule /^#{highlights_dir}\/[[:xdigit:]]+\.html$/ =>
  [->(highlight_file){listing_for_highlight_file(highlight_file)}] do |t|
  dir = t.name.pathmap("%d")
  mkdir_p dir unless File.exist?(dir)
  sh *%W[pygmentize -o #{t.name} #{t.source}]
end
```

I would like to shorten it to this rule by using a `Method` object:

``` ruby
rule /^#{highlights_dir}\/[[:xdigit:]]+\.html$/ => [method(:listing_for_highlight_file)] do |t|
  dir = t.name.pathmap("%d")
  mkdir_p dir unless File.exist?(dir)
  sh *%W[pygmentize -o #{t.name} #{t.source}]
end
```

But this is not currently possible because rules expect executable prerequisites to be `Proc` instances.
