### PR TITLE
empty? method on TaskArguments

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -62,6 +62,10 @@ module Rake
       lookup(sym.to_sym)
     end
 
+    def empty?
+      @hash.empty?
+    end  
+
     def to_hash
       @hash
     end


### PR DESCRIPTION
I wanted to write a task that accepted arguments, but if they were not provided, set default values in the body of the task. 
Turned out args.empty? always returns false because the missing method sends it to the lookup method which just states that :empty? is no known key. 

So, according to the principle of least surprise (POLS), I suggest that args.empty? just does the obvious thing, and returns true if the hash is empty.

Rake is so venerable and old, I'm surprised I'm the first to bump into this. But hey, good opportunity to say hello and submit a PR.

PS: And then I saw that there is args.with_defaults, which makes the case for this PR weaker. It might still be a good idea, because the external representation of TaskArgument is a hash, and I would expect it to behave like a hash. You'll certainly know better whether this PR is desirable or not. Thanks! 

PS: S: And then I understood the interface. empty? is indeed not necessary. Closing PR. I guess I got confused by Thor which If I'm not mistaken treats args as a regular hash. Read the manual? Okay then...  
