### PR TITLE
Fix a test failure on Windows

### DIFF
--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -11,7 +11,7 @@ class TestBacktraceSuppression < Rake::TestCase
   end
 
   def test_system_dir_suppressed
-    path = RbConfig::CONFIG['rubylibprefix']
+    path = File.expand_path(RbConfig::CONFIG['rubylibprefix'])
     skip if path.nil?
 
     paths = [path + ":12"]
@@ -22,7 +22,7 @@ class TestBacktraceSuppression < Rake::TestCase
   end
 
   def test_near_system_dir_isnt_suppressed
-    path = RbConfig::CONFIG['rubylibprefix']
+    path = File.expand_path(RbConfig::CONFIG['rubylibprefix'])
     skip if path.nil?
 
     paths = [" " + path + ":12"]


### PR DESCRIPTION
test-all on ruby repository fails because the path doesn't have a
drive letter (C:) on Windows. Rake::Backtrace.collapse also uses
File.expand_path internally to make suppressed paths.

See:
http://ci.rubyinstaller.org/job/ruby-trunk-x64-test-all/2051/console

```
  1) Failure:
TestBacktraceSuppression#test_system_dir_suppressed [C:/Users/Worker/Jenkins/workspace/ruby-trunk-x64-build/test/rake/test_rake_backtrace.rb:19]:
Expected: []
  Actual: ["/usr/local/lib/ruby:12"]
```
