### PR TITLE
Completed namespaced task definitions

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -22,6 +22,13 @@ module Rake
 
     def define_task(task_class, *args, &block)
       task_name, arg_names, deps = resolve_args(args)
+
+      original_scope = @scope
+      if(task_name.is_a? String)
+        task_name, *definition_scope = *(task_name.split(":").reverse)
+        @scope = Scope.make(*(definition_scope + @scope.to_a))
+      end
+
       task_name = task_class.scope_name(@scope, task_name)
       deps = [deps] unless deps.respond_to?(:to_ary)
       deps = deps.map { |d| d.to_s }
@@ -32,6 +39,8 @@ module Rake
         task.add_description(get_description(task))
       end
       task.enhance(deps, &block)
+    ensure
+      @scope = original_scope
     end
 
     # Lookup a task.  Return an existing task if found, otherwise

--- a/test/test_rake_task_manager.rb
+++ b/test/test_rake_task_manager.rb
@@ -40,6 +40,23 @@ class TestRakeTaskManager < Rake::TestCase
     assert_equal ["x:t"], @tm.tasks.map { |t| t.name }
   end
 
+  def test_define_namespaced_task
+    t = @tm.define_task(Rake::Task, 'n:a:m:e:t')
+    assert_equal Rake::Scope.make("e", "m", "a", "n"), t.scope
+    assert_equal "n:a:m:e:t", t.name
+    assert_equal @tm, t.application
+  end
+
+  def test_define_namespace_in_namespace
+    t = nil
+    @tm.in_namespace("n") do
+      t = @tm.define_task(Rake::Task, 'a:m:e:t')
+    end
+    assert_equal Rake::Scope.make("e", "m", "a", "n"), t.scope
+    assert_equal "n:a:m:e:t", t.name
+    assert_equal @tm, t.application
+  end
+
   def test_anonymous_namespace
     anon_ns = @tm.in_namespace(nil) do
       t = @tm.define_task(Rake::Task, :t)
@@ -89,6 +106,7 @@ class TestRakeTaskManager < Rake::TestCase
     @tm.in_namespace("a") do
       aa = @tm.define_task(Rake::Task, :aa)
       mid_z = @tm.define_task(Rake::Task, :z)
+      ns_d = @tm.define_task(Rake::Task, "n:t")
       @tm.in_namespace("b") do
         bb = @tm.define_task(Rake::Task, :bb)
         bot_z = @tm.define_task(Rake::Task, :z)
@@ -116,6 +134,8 @@ class TestRakeTaskManager < Rake::TestCase
       assert_equal top_z, @tm["^z"]
       assert_equal top_z, @tm["^^z"] # Over the top
       assert_equal top_z, @tm["rake:z"]
+      assert_equal ns_d, @tm["n:t"]
+      assert_equal ns_d, @tm["a:n:t"]
     end
 
     assert_equal Rake::Scope.make, @tm.current_scope


### PR DESCRIPTION
Tests include working within another namespace, and that the TM scope isn't
clobbered

Allows for syntax like:

```
task "namespace:taskname" do
end
```

as equivalent to 

```
namespace :namespace do
  task :taskname do
  end
end
```

regardless of where it appears in the Rakefile.
