### PR TITLE
TaskArgument responds to has_key?

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -74,6 +74,10 @@ module Rake
       to_s
     end
 
+    def has_key?(key)
+      @hash.has_key?(key)
+    end
+
     protected
 
     def lookup(name)

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -19,6 +19,12 @@ class TestRakeTaskArguments < Rake::TestCase
     assert_equal({:a => :one, :b => :two, :c => :three}, ta.to_hash)
   end
 
+  def test_has_key
+    ta = Rake::TaskArguments.new([:a], [:one])
+    assert(ta.has_key?(:a))
+    refute(ta.has_key?(:b))
+  end
+
   def test_to_s
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
     assert_equal ta.to_hash.inspect, ta.to_s


### PR DESCRIPTION
TaskArgument looks like a duck and walks like a duck, but quacks like a goose.

Because of the method_missing calling args.has_key? will always return nil (unless for some reason you have a task argument called has_key?, but that's a whole other issue). This was confusing to me, and I'll be it's confusing to other folks as well. I considered mimicking other Hash methods, but I think has_key is the only one that fails in a non-obvious way.

``` ruby
task :test, :email do |t, args|
  if args.has_key?(:email)
    puts "got #{args[:email]}"
  else
    puts "kinda sad"
  end
end
```
