### PR TITLE
collect_tasks to collect_tasks_from_cmd_line

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -84,7 +84,7 @@ module Rake
       standard_exception_handling do
         @name = app_name
         handle_options
-        collect_tasks
+        collect_tasks_from_cmd_line
       end
     end
 
@@ -685,7 +685,7 @@ module Rake
     # Collect the list of tasks on the command line.  If no tasks are
     # given, return a list containing only the default task.
     # Environmental assignments are processed at this time as well.
-    def collect_tasks
+    def collect_tasks_from_cmd_line
       @top_level_tasks = []
       ARGV.each do |arg|
         if arg =~ /^(\w+)=(.*)$/m

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -113,6 +113,16 @@ module Rake
       end
     end
 
+    #(task "a").do_first
+
+    def do_first(deps=nil,&block)
+      deps = [deps] unless deps.nil? or deps.respond_to?(:to_ary)
+      deps = deps.map{|d| d.to_s} if deps
+      @prerequisites = deps | @prerequisites if deps
+      @actions.unshift block if block_given?
+      self
+    end
+
     # Argument description (nil if none).
     def arg_description # :nodoc:
       @arg_names ? "[#{arg_names.join(',')}]" : nil

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -265,6 +265,40 @@ class TestRakeTask < Rake::TestCase
     assert_in_delta now, a.timestamp, 0.1, 'computer too slow?'
   end
 
+  def test_do_first_with_deps_adds_deps_to_front_of_prerequisites
+    a = task :a => ["b", "c"]
+    b = task :b
+    c = task :c
+    d = task :d
+
+    a.do_first [d]
+    assert_equal ["d","b","c"], Task["a"].prerequisites
+  end  
+
+  def test_do_first_with_deps_is_additive
+    a = task :a =>["b","c"]
+    b = task :b
+    c = task :c
+    d = task :d
+    e = task :e
+    a.do_first [d]
+    a.do_first [e]
+    assert_equal ["e","d","b","c"], Task["a"].prerequisites
+  end
+
+  def test_do_first_with_action_block_unshifts_block_to_actions
+    result = []
+    a = task :a do
+      result << 'first'
+    end
+
+    a.do_first do 
+      result << 'second'
+    end
+    Task["a"].invoke
+    assert_equal ['second','first'], result
+  end 
+
   def test_always_multitask
     mx = Mutex.new
     result = []


### PR DESCRIPTION
When reading the code, it was kind of confusing because collect_tasks seems to imply that it is collecting the tasks from all the tasks. I changed this to collect_tasks_from_cmd_line to be more inline with the comments and the intent
