### PR TITLE
Fix explanation of directory method in the rakefile.doc

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -97,9 +97,9 @@ that creates the directory.  For example, the following declaration
 
 is equivalent to ...
 
-  file "testdata"              do |t| mkdir t.name end
-  file "testdata/examples"     do |t| mkdir t.name end
-  file "testdata/examples/doc" do |t| mkdir t.name end
+  file "testdata" do |t| mkdir t.name end
+  file "testdata/examples" => ["testdata"] do |t| mkdir t.name end
+  file "testdata/examples/doc" => ["testdata/examples"] do |t| mkdir t.name end
 
 The +directory+ method does not accept prerequisites or actions, but
 both prerequisites and actions can be added later.  For example ...


### PR DESCRIPTION
The code

``` ruby
file "testdata"              do |t| mkdir t.name end
file "testdata/examples"     do |t| mkdir t.name end
file "testdata/examples/doc" do |t| mkdir t.name end
```

is not the same as `directory "testdata/examples/doc"` because the task defined with `file "testdata/examples/doc" do |t| mkdir t.name end` will cause error saying that there is no folder `testdata`. So I think that they are not equal that's why.

They will be also equal with this file task definition: `file "testdata/examples/doc" do |t| mkdir_p t.name end`
