### PR TITLE
Updated Gem::Specification to require Ruby >= 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -169,7 +169,7 @@ Rake is a Make-like program implemented in Ruby. Tasks and dependencies are
 specified in standard Ruby syntax.
     EOF
 
-    s.required_ruby_version = '>= 1.8.6'
+    s.required_ruby_version = '>= 1.9'
     s.required_rubygems_version = '>= 1.3.2'
     s.add_development_dependency 'minitest', '~> 4'
 


### PR DESCRIPTION
This is given the changes in 93c4491ca0716730097e08e44c7a50885b447cc3
