### PR TITLE
-P plus -v then show prereqs verbose

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -332,7 +332,7 @@ module Rake
       if options.show_prereqs_verbose
         def recursion(tasks, indentlevel=0)
           tasks.each do |t|
-            puts "#{'  '*indentlevel}#{t.class.name.split('::')[-1].downcase}  #{t.name}"
+            puts "#{'  '*indentlevel}#{t.class.name.split('::')[-1].downcase}  #{t.name}  #{t.locations}"
             recursion(t.prerequisite_tasks, indentlevel+1)
           end
         end
@@ -540,6 +540,7 @@ module Rake
             "Log message to standard output.",
             lambda { |value|
               options.show_prereqs_verbose = true
+              Rake::TaskManager.record_task_metadata = true
               Rake.verbose(true)
             }
           ],

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -329,9 +329,19 @@ module Rake
 
     # Display the tasks and prerequisites
     def display_prerequisites
-      tasks.each do |t|
-        puts "#{name} #{t.name}"
-        t.prerequisites.each { |pre| puts "    #{pre}" }
+      if options.show_prereqs_verbose
+        def recursion(tasks, indentlevel=0)
+          tasks.each do |t|
+            puts "#{'  '*indentlevel}#{t.class.name.split('::')[-1].downcase}  #{t.name}"
+            recursion(t.prerequisite_tasks, indentlevel+1)
+          end
+        end
+        recursion(tasks)
+      else
+        tasks.each do |t|
+          puts "#{name} #{t.name}"
+          t.prerequisites.each { |pre| puts "    #{pre}" }
+        end
       end
     end
 
@@ -444,7 +454,7 @@ module Rake
             lambda { |value| options.nosearch = true }
           ],
           ['--prereqs', '-P',
-            "Display the tasks and dependencies, then exit.",
+            "Display the tasks and dependencies, then exit. (have -v then show verbose)",
             lambda { |value| options.show_prereqs = true }
           ],
           ['--quiet', '-q',
@@ -528,7 +538,10 @@ module Rake
           ],
           ['--verbose', '-v',
             "Log message to standard output.",
-            lambda { |value| Rake.verbose(true) }
+            lambda { |value|
+              options.show_prereqs_verbose = true
+              Rake.verbose(true)
+            }
           ],
           ['--version', '-V',
             "Display the program version.",

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -330,16 +330,12 @@ module Rake
     # Display the tasks and prerequisites
     def display_prerequisites
       if options.show_prereqs_verbose
-        if Rake.application.windows?
-          tasks.each do |t|
-            t.locations.map! do |loc|
+        tasks.each do |t|
+          t.locations.map! do |loc|
+            if loc[1,2] == ':/' # windows absolute path
               drive, path, lineno = loc.split(':')
               "#{drive}:#{path}:#{lineno}"
-            end
-          end
-        else
-          tasks.each do |t|
-            t.locations.map! do |loc|
+            else
               fn, lineno = loc.split(':')
               "#{fn}:#{lineno}"
             end

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -330,6 +330,21 @@ module Rake
     # Display the tasks and prerequisites
     def display_prerequisites
       if options.show_prereqs_verbose
+        if Rake.application.windows?
+          tasks.each do |t|
+            t.locations.map! do |loc|
+              drive, path, lineno = loc.split(':')
+              "#{drive}:#{path}:#{lineno}"
+            end
+          end
+        else
+          tasks.each do |t|
+            t.locations.map! do |loc|
+              fn, lineno = loc.split(':')
+              "#{fn}:#{lineno}"
+            end
+          end
+        end
         def recursion(tasks, indentlevel=0)
           tasks.each do |t|
             puts "#{'  '*indentlevel}#{t.class.name.split('::')[-1].downcase}  #{t.name}  #{t.locations}"


### PR DESCRIPTION
if command line have `-P` and `-v` parameters, recursion show prerequires and show task define locations.

rake -P

```
rake a1
rake a2
    a1
rake b1
rake b2
    b1
rake c1
    a2
    b2
```

rake -P -v

```
task  a1  ["bb/a1.rake:6", "bb/a1.rake:15"]
task  a2  ["bb/a2.rake:4"]
  task  a1  ["bb/a1.rake:6", "bb/a1.rake:15"]
filetask  b1  ["bb/b1.rake:5"]
task  b2  ["bb/b1.rake:10", "/tmp/aa/Rakefile.rb:53"]
  filetask  b1  ["bb/b1.rake:5"]
task  c1  ["/tmp/aa/Rakefile.rb:56", "/tmp/aa/Rakefile.rb:57"]
  task  a2  ["bb/a2.rake:4"]
    task  a1  ["bb/a1.rake:6", "bb/a1.rake:15"]
  task  b2  ["bb/b1.rake:10", "/tmp/aa/Rakefile.rb:53"]
    filetask  b1  ["bb/b1.rake:5"]
```
