### PR TITLE
Log exception classes

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -184,7 +184,7 @@ module Rake
     # Display the error message that caused the exception.
     def display_error_message(ex)
       trace "#{name} aborted!"
-      trace ex.message
+      trace error_message(ex)
       if options.backtrace
         trace ex.backtrace.join("\n")
       else
@@ -193,6 +193,14 @@ module Rake
       trace "Tasks: #{ex.chain}" if has_chain?(ex)
       trace "(See full trace by running task with --trace)" unless
         options.backtrace
+    end
+
+    def error_message(ex)
+      if ex.is_a?(RuntimeError)
+        ex.message
+      else
+        ex.class.name + ': ' + ex.message
+      end
     end
 
     # Warn about deprecated usage.

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -196,7 +196,7 @@ module Rake
     end
 
     def error_message(ex)
-      if ex.is_a?(RuntimeError)
+      if ex.instance_of?(RuntimeError)
         ex.message
       else
         ex.class.name + ': ' + ex.message

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -100,6 +100,18 @@ class TestRakeBacktrace < Rake::TestCase
     refute_match %r!Rakefile!i, lines[2]
   end
 
+  def test_exception_class_name
+    rakefile %q{
+      task :baz do
+        raise StandardError, "bazzz!"
+      end
+    }
+
+    lines = invoke("baz").split("\n")
+    assert_equal "rake aborted!", lines[0]
+    assert_equal "StandardError: bazzz!", lines[1]
+  end
+
   private
 
   # Assert that the pattern matches at least one line in +lines+.

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -102,14 +102,16 @@ class TestRakeBacktrace < Rake::TestCase
 
   def test_exception_class_name
     rakefile %q{
+      CustomError = Class.new(RuntimeError)
+
       task :baz do
-        raise StandardError, "bazzz!"
+        raise CustomError, "bazzz!"
       end
     }
 
     lines = invoke("baz").split("\n")
     assert_equal "rake aborted!", lines[0]
-    assert_equal "StandardError: bazzz!", lines[1]
+    assert_equal "CustomError: bazzz!", lines[1]
   end
 
   private


### PR DESCRIPTION
Exception class names can often provide useful debugging information as they tend to be very descriptive.
