### PR TITLE
Clarify rake -f usage.

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -451,8 +451,8 @@ module Rake
             "Do not log messages to standard output.",
             lambda { |value| Rake.verbose(false) }
           ],
-          ['--rakefile', '-f [FILE]',
-            "Use FILE as the rakefile.",
+          ['--rakefile', '-f [FILENAME]',
+            "Use FILENAME as the rakefile to search for.",
             lambda { |value|
               value ||= ''
               @rakefiles.clear


### PR DESCRIPTION
Users that are used to make semantics might not expect,
that parent directories are still being searched.
