### PR TITLE
Add build_all capability.

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -365,6 +365,12 @@ module Rake
               select_trace_output(options, 'backtrace', value)
             }
           ],
+          ['--build-all', '-B',
+           "Build all prerequisites, including those which are up-to-date.",
+           lambda { |value|
+             options.build_all = true
+           }
+          ],
           ['--comments',
             "Show commented tasks only",
             lambda { |value|

--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -13,7 +13,7 @@ module Rake
     # Is this file task needed?  Yes if it doesn't exist, or if its time stamp
     # is out of date.
     def needed?
-      ! File.exist?(name) || out_of_date?(timestamp)
+      ! File.exist?(name) || out_of_date?(timestamp) || @application.options.build_all
     end
 
     # Time stamp for file task.


### PR DESCRIPTION
It is supposed to be the equivalent of the `-B` option in GNU Make. It makes Rake act like all the files created by file targets are out of date.
