### PR TITLE
CpuCounter: use count_via_sysctl for all bsd's

### DIFF
--- a/lib/rake/cpu_counter.rb
+++ b/lib/rake/cpu_counter.rb
@@ -26,7 +26,7 @@ module Rake
           count_via_hwprefs_thread_count || count_via_sysctl
         when /linux/
           count_via_cpuinfo
-        when /freebsd/
+        when /bsd/
           count_via_sysctl
         when /mswin|mingw/
           count_via_win32


### PR DESCRIPTION
FreeBSD, NetBSD, and OpenBSD and all forks that retain "bsd" in the os
name most likely have `sysctl hw.ncpu`, so try count_via_sysctl first
