### PR TITLE
Lookup prerequisites with same name outside of scope instead of matching self

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -54,7 +54,11 @@ module Rake
     end
 
     def lookup_prerequisite(prerequisite_name) # :nodoc:
-      application[prerequisite_name, @scope]
+      scoped_prerequisite_task = application[prerequisite_name, @scope]
+      if scoped_prerequisite_task == self
+        unscoped_prerequisite_task = application[prerequisite_name]
+      end
+      unscoped_prerequisite_task || scoped_prerequisite_task
     end
     private :lookup_prerequisite
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -194,14 +194,14 @@ class TestRakeTask < Rake::TestCase
     assert_equal ["b", "c"], Task[:a].prerequisites
   end
 
-  def test_prerequiste_tasks_returns_tasks_not_strings
+  def test_prerequisite_tasks_returns_tasks_not_strings
     a = task :a => ["b", "c"]
     b = task :b
     c = task :c
     assert_equal [b, c], a.prerequisite_tasks
   end
 
-  def test_prerequiste_tasks_fails_if_prerequisites_are_undefined
+  def test_prerequisite_tasks_fails_if_prerequisites_are_undefined
     a = task :a => ["b", "c"]
     task :b
     assert_raises(RuntimeError) do
@@ -209,7 +209,8 @@ class TestRakeTask < Rake::TestCase
     end
   end
 
-  def test_prerequiste_tasks_honors_namespaces
+  def test_prerequisite_tasks_honors_namespaces
+    task :b
     a = b = nil
     namespace "X" do
       a = task :a => ["b", "c"]
@@ -218,6 +219,35 @@ class TestRakeTask < Rake::TestCase
     c = task :c
 
     assert_equal [b, c], a.prerequisite_tasks
+  end
+
+  def test_prerequisite_tasks_finds_tasks_with_same_name_outside_namespace
+    b1 = nil
+    namespace "a" do
+      b1 = task :b => "b"
+    end
+    b2 = task :b
+
+    assert_equal [b2], b1.prerequisite_tasks
+  end
+
+  def test_prerequisite_tasks_in_nested_namespaces
+    m = task :m
+    a_c_m = a_b_m = a_m = nil
+    namespace "a" do
+      a_m = task :m
+
+      namespace "b" do
+        a_b_m = task :m => "m"
+      end
+
+      namespace "c" do
+        a_c_m = task :m => "a:m"
+      end
+    end
+
+    assert_equal [m], a_b_m.prerequisite_tasks
+    assert_equal [a_m], a_c_m.prerequisite_tasks
   end
 
   def test_all_prerequisite_tasks_includes_all_prerequisites


### PR DESCRIPTION
`Task#lookup_prerequisite` finds self if looking up a prerequisite outside of the namespace with the same task name. Behavior in this case is debatable but at least there should be a way to specify to lookup the task outside of the scope instead of ending the chain with a circular reference. If this default behavior I have implemented looks good this solves the problem by convention. Otherwise notation will need to be introduced such as

``` ruby
task :b
namespace "a" do
  task :b => "global:b"
end
```

Where global signifies to lookup outside the namespace.
