### PR TITLE
Don't report an error when cleaning missing files

### DIFF
--- a/lib/rake/clean.rb
+++ b/lib/rake/clean.rb
@@ -29,10 +29,23 @@ module Rake
 
     def cleanup(file_name, opts={})
       begin
-        rm_r file_name, opts if File.exist? file_name
+        rm_r file_name, opts
       rescue StandardError => ex
-        puts "Failed to remove #{file_name}: #{ex}"
+        puts "Failed to remove #{file_name}: #{ex}" unless file_already_gone?(file_name)
       end
+    end
+
+    private
+
+    def self.file_already_gone?(file_name)
+      return false if File.exist?(file_name)
+
+      path = file_name
+      while path = File.dirname(path)
+        return false unless File.readable?(path) && File.executable?(path)
+        break if ["/", "."].include?(path)
+      end
+      true
     end
   end
 end

--- a/lib/rake/clean.rb
+++ b/lib/rake/clean.rb
@@ -35,9 +35,7 @@ module Rake
       end
     end
 
-    private
-
-    def self.file_already_gone?(file_name)
+    def file_already_gone?(file_name)
       return false if File.exist?(file_name)
 
       path = file_name
@@ -47,6 +45,7 @@ module Rake
       end
       true
     end
+    private_class_method :file_already_gone?
   end
 end
 

--- a/lib/rake/clean.rb
+++ b/lib/rake/clean.rb
@@ -29,7 +29,7 @@ module Rake
 
     def cleanup(file_name, opts={})
       begin
-        rm_r file_name, opts
+        rm_r file_name, opts if File.exist? file_name
       rescue StandardError => ex
         puts "Failed to remove #{file_name}: #{ex}"
       end

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -39,8 +39,8 @@ class TestRakeClean < Rake::TestCase
     file_name = File.join(dir_name, "deleteme")
     FileUtils.mkdir(dir_name)
     FileUtils.touch(file_name)
-    FileUtils.chmod(0400, file_name)
-    FileUtils.chmod(0500, dir_name)
+    FileUtils.chmod(0, file_name)
+    FileUtils.chmod(0, dir_name)
     file_name
   end
 

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -23,6 +23,15 @@ class TestRakeClean < Rake::TestCase
     remove_undeletable_file
   end
 
+  def test_cleanup_ignores_missing_files
+    file_name = File.join(@tempdir, "missing_directory" "no_such_file")
+
+    out, _ = capture_io do
+      Rake::Cleaner.cleanup(file_name, :verbose => false)
+    end
+    refute_match(/failed to remove/i, out)
+  end
+
   private
 
   def create_undeletable_file
@@ -30,8 +39,8 @@ class TestRakeClean < Rake::TestCase
     file_name = File.join(dir_name, "deleteme")
     FileUtils.mkdir(dir_name)
     FileUtils.touch(file_name)
-    FileUtils.chmod(0, file_name)
-    FileUtils.chmod(0, dir_name)
+    FileUtils.chmod(0400, file_name)
+    FileUtils.chmod(0500, dir_name)
     file_name
   end
 


### PR DESCRIPTION
When doing a `rake clean` or `rake clobber`, it is often the case that
some of the files don't exist.  The desired end state of the clean or
clobber task is that the specified files no longer be present at the
end of the task; if they weren't there in the first place, the
post-condition is still satisfied.

Without this change, running a `rake clean` or `rake clobber` is too
noisy, and yet silently failing to delete a file is not a good
solution either.

This may not be the best fix for this.  I tried two options:

1) Add a second rescue block for `Errno::ENOENT`.  This fails
`test_cleanup` in JRuby, because JRuby raises `Errno::ENOENT` for that
case.

2) Use `File.exist?` as I've done.  In order to make this work, I had
to modify the permissions used in `create_undeletable_file`, because
`File.exist?` returns false for a file in an unreadable directory.

With either of these solutions, there are corner cases where one or
more Ruby implementations will silently fail to delete a file.  My
opinion is that those corner cases are rare enough that this PR makes
sense for the far more common case.
