### PR TITLE
Support Pathname

### DIFF
--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -98,6 +98,7 @@ module Rake
     def directory(*args, &block) # :doc:
       result = file_create(*args, &block)
       dir, _ = *Rake.application.resolve_args(args)
+      dir = Rake.from_pathname(dir)
       Rake.each_dir_parent(dir) do |d|
         file_create d do |t|
           mkdir_p t.name unless File.exist?(t.name)

--- a/lib/rake/ext/pathname.rb
+++ b/lib/rake/ext/pathname.rb
@@ -1,0 +1,25 @@
+require 'rake/ext/core'
+require 'pathname'
+
+class Pathname
+
+  rake_extension("ext") do
+    # Return a new Pathname with <tt>String#ext</tt> applied to it.
+    #
+    # This Pathname extension comes from Rake
+    def ext(newext='')
+      Pathname.new(Rake.from_pathname(self).ext(newext))
+    end
+  end
+
+  rake_extension("pathmap") do
+    # Apply the pathmap spec to the Pathname, returning a
+    # new Pathname with the modified paths.  (See String#pathmap for
+    # details.)
+    #
+    # This Pathname extension comes from Rake
+    def pathmap(spec=nil, &block)
+      Pathname.new(Rake.from_pathname(self).pathmap(spec, &block))
+    end
+  end
+end

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -49,7 +49,7 @@ module Rake
 
     # List of methods that should not be delegated here (we define special
     # versions of them explicitly below).
-    MUST_NOT_DEFINE = %w[to_a to_ary partition *]
+    MUST_NOT_DEFINE = %w[to_a to_ary partition * <<]
 
     # List of delegated methods that return new array values which need
     # wrapping.
@@ -119,7 +119,7 @@ module Rake
         if fn.respond_to? :to_ary
           include(*fn.to_ary)
         else
-          @pending_add << fn
+          @pending_add << Rake.from_pathname(fn)
         end
       end
       @pending = true
@@ -149,7 +149,7 @@ module Rake
     #
     def exclude(*patterns, &block)
       patterns.each do |pat|
-        @exclude_patterns << pat
+        @exclude_patterns << Rake.from_pathname(pat)
       end
       @exclude_procs << block if block_given?
       resolve_exclude unless @pending
@@ -194,6 +194,12 @@ module Rake
       else
         result
       end
+    end
+
+    def <<(obj)
+      resolve
+      @items << Rake.from_pathname(obj)
+      self
     end
 
     # Resolve all the pending adds now.
@@ -409,6 +415,14 @@ module Rake
         old_length = dir.length
         dir = File.dirname(dir)
       end
+    end
+
+    # Convert Pathname and Pathname-like objects to strings;
+    # leave everything else alone
+    def from_pathname(path)    # :nodoc:
+      path = path.to_path if path.respond_to?(:to_path)
+      path = path.to_str if path.respond_to?(:to_str)
+      path
     end
   end
 end # module Rake

--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -39,7 +39,7 @@ module Rake
       # Apply the scope to the task name according to the rules for this kind
       # of task.  File based tasks ignore the scope when creating the name.
       def scope_name(scope, task_name)
-        task_name
+        Rake.from_pathname(task_name)
       end
     end
   end

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -35,7 +35,7 @@ module Rake
 
       task_name = task_class.scope_name(@scope, task_name)
       deps = [deps] unless deps.respond_to?(:to_ary)
-      deps = deps.map { |d| d.to_s }
+      deps = deps.map { |d| Rake.from_pathname(d).to_s }
       task = intern(task_class, task_name)
       task.set_arg_names(arg_names) unless arg_names.empty?
       if Rake::TaskManager.record_task_metadata

--- a/test/test_rake_directory_task.rb
+++ b/test/test_rake_directory_task.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 require 'fileutils'
+require 'pathname'
 
 class TestRakeDirectoryTask < Rake::TestCase
   include Rake
@@ -58,6 +59,18 @@ class TestRakeDirectoryTask < Rake::TestCase
     assert_equal Task["a/b/c"], t1
     assert_equal FileCreationTask, Task["a/b/c"].class
     assert_equal ["t2", "a/b/c"], runlist
+    assert File.directory?("a/b/c")
+  end
+
+  def test_can_use_pathname
+    directory Pathname.new "a/b/c"
+
+    assert_equal FileCreationTask, Task["a/b/c"].class
+
+    verbose(false) {
+      Task['a/b/c'].invoke
+    }
+
     assert File.directory?("a/b/c")
   end
 end

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../helper', __FILE__)
+require 'pathname'
 
 class TestRakeFileList < Rake::TestCase
   FileList = Rake::FileList
@@ -46,6 +47,12 @@ class TestRakeFileList < Rake::TestCase
       fl.sort
   end
 
+  def test_create_with_pathname
+    fl = FileList.new(Pathname.new("*.c"))
+    assert_equal ["abc.c", "x.c", "xyz.c"].sort,
+                 fl.sort
+  end
+
   def test_create_with_block
     fl = FileList.new { |f| f.include("x") }
     assert_equal ["x"], fl.resolve
@@ -74,10 +81,22 @@ class TestRakeFileList < Rake::TestCase
       fl.sort
   end
 
+  def test_include_with_pathname
+    fl = FileList.new.include(Pathname.new("*.c"))
+    assert_equal ["abc.c", "x.c", "xyz.c"].sort,
+      fl.sort
+  end
+
   def test_append
     fl = FileList.new
     fl << "a.rb" << "b.rb"
     assert_equal ['a.rb', 'b.rb'], fl
+  end
+
+  def test_append_pathname
+    fl = FileList.new
+    fl << Pathname.new("a.rb")
+    assert_equal ['a.rb'], fl
   end
 
   def test_add_many
@@ -161,6 +180,15 @@ class TestRakeFileList < Rake::TestCase
     fl.exclude('existing')
 
     assert_equal [], fl
+  end
+
+  def test_exclude_pathname
+    fl = FileList['x.c', 'abc.c', 'other']
+    fl.each { |fn| touch fn, :verbose => false }
+
+    fl.exclude(Pathname.new('*.c'))
+
+    assert_equal ['other'], fl
   end
 
   def test_excluding_via_block

--- a/test/test_rake_file_task.rb
+++ b/test/test_rake_file_task.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 require 'fileutils'
+require 'pathname'
 
 class TestRakeFileTask < Rake::TestCase
   include Rake
@@ -160,6 +161,20 @@ class TestRakeFileTask < Rake::TestCase
   def test_sources_is_all_prerequisites
     t = file :f => ["preqA", "preqB"]
     assert_equal ["preqA", "preqB"], t.sources
+  end
+
+  def test_task_can_be_pathname
+      name = "dummy"
+      file Pathname.new name
+
+      ftask = Task[name]
+
+      assert_equal name.to_s, ftask.name
+  end
+
+  def test_prerequisite_can_be_pathname
+    t = file :f => Pathname.new("preq")
+    assert_equal "preq", t.source
   end
 
   # I have currently disabled this test.  I'm not convinced that

--- a/test/test_rake_pathname_extensions.rb
+++ b/test/test_rake_pathname_extensions.rb
@@ -1,0 +1,15 @@
+require File.expand_path('../helper', __FILE__)
+require 'rake/ext/pathname'
+
+class TestRakePathnameExtensions < Rake::TestCase
+  def test_ext_works_on_pathnames
+    pathname = Pathname.new("abc.foo")
+    assert_equal Pathname.new("abc.bar"), pathname.ext("bar")
+  end
+
+  def test_path_map_works_on_pathnames
+    pathname = Pathname.new("this/is/a/dir/abc.rb")
+    assert_equal Pathname.new("abc.rb"), pathname.pathmap("%f")
+    assert_equal Pathname.new("this/is/a/dir"), pathname.pathmap("%d")
+  end
+end


### PR DESCRIPTION
These two commits allow client code to use Pathnames when working with Rake.  The first commit allows transparent use of Pathnames in FileList, file/directory tasks, and as task prerequisites.  The second adds the `ext` and `pathname` extension methods to `Pathname`.

I believe I caught all of the places where Pathnames might be used, but it is possible that I missed something.

The basic philosophy I followed was to convert incoming Pathnames to strings as soon as possible, and allow Rake to work with strings as it always has.

I'd like to find a way to have the `ext` and `pathmap` extensions defined automatically if the client code requires 'pathmap'; I didn't want to make Rake require `pathmap` itself and force it into client code.
