### PR TITLE
Ignore falsey dependencies

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -111,7 +111,7 @@ module Rake
       if args.empty?
         task_name = key
         arg_names = []
-        deps = value
+        deps = value || []
       else
         task_name = args.shift
         arg_names = key

--- a/test/test_rake_definitions.rb
+++ b/test/test_rake_definitions.rb
@@ -59,6 +59,11 @@ class TestRakeDefinitions < Rake::TestCase
     assert_raises(RuntimeError) { Task[:x].invoke }
   end
 
+  def test_falsey_dependencies
+    task :x => nil
+    assert_equal [], Task[:x].prerequisites
+  end
+
   def test_implicit_file_dependencies
     runs = []
     create_existing_file


### PR DESCRIPTION
When creating Rake tasks programatically, it could so happen that the prerequisites reach the point of creation as an argument. Here is an example from one of my `Rakefiles`:

```
def make_lang_task(lang, action, args)
  desc "#{action} #{lang} #{args}"
  prereqs = args[:prereqs] || [] # NOTE: Special handling of nil
  task lang => prereqs do
    Rake::Task["#{lang}:#{action}"].invoke(args)
  end
end
```

This change teaches the Rake DSL to ignore falsey (`nil` or `false`) values when they are specified as the dependencies. This way, programmatic creation does not have to deal with a special case -- the `prereqs = args[:prereqs] || []` line in the example above. So it can be written as

```
def make_lang_task(lang, action, args)
  desc "#{action} #{lang} #{args}"
  task lang => args[:prereqs] do
    Rake::Task["#{lang}:#{action}"].invoke(args)
  end
end
```

I'm myself not fully sure if this change gels in well with Rake, so feel free to close this if you feel that this is an edge case that should be handled by the callers themselves.
