### PR TITLE
Document argument parsing change in test

### DIFF
--- a/test/test_rake_task_argument_parsing.rb
+++ b/test/test_rake_task_argument_parsing.rb
@@ -49,6 +49,16 @@ class TestRakeTaskArgumentParsing < Rake::TestCase
     assert_equal ["one", "two", "three_a, three_b", "four"], args
   end
 
+  def test_treat_blank_arg_as_empty_string
+    name, args = @app.parse_task_string("name[one,]")
+    assert_equal "name", name
+    assert_equal ["one", ""], args
+
+    name, args = @app.parse_task_string("name[one,,two]")
+    assert_equal "name", name
+    assert_equal ["one", "", "two"], args
+  end
+
   def test_terminal_width_using_env
     app = Rake::Application.new
     app.terminal_columns = 1234


### PR DESCRIPTION
There were explicit changes in argument parsing behavior since 10.1.1, but there also seems to be some undocumented changes in handling of some parameters. I actually think the new behavior is more sane, so here's a pr to document the current behavior in tests.

In 10.1.1, 'empty' args were not included in the arg array returned from `parse_task_string`. In 10.3.2 'empty' args are pass as empty string.

```
#10.3.2
name, args = @app.parse_task_string("name[one,]") 

name # => 'name'
args # => ['one', '']
```

```
#10.1.1
name, args = @app.parse_task_string("name[one,]") 

name # => 'name'
args # => ['one']
```
